### PR TITLE
docs: refine vcrunch spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ This file applies to the entire repository.
 
 Scripts are containerised for cross‑platform use with Podman. Host-specific helpers (e.g. in `osx/`) are only for tasks that do not containerise cleanly.
 
-Each Podman script directory must include a `spec.md` written using modern Gauge conventions (`Scenario:` headings and `Given`/`When`/`Then` steps with parameter placeholders). Specs should contain the minimal scenarios necessary for complete coverage of the script's features. Use a single spec per platform-specific directory (e.g. `osx/spec.md`). If needed, keep script-specific terminology in a `glossary.md` alongside the spec.
+Each Podman script directory must include a `spec.md` written using modern Gauge conventions (`Scenario:` headings and `Given`/`When`/`Then` steps with parameter placeholders). Break steps into single, atomic actions and expectations to keep scenarios easily testable. For CLI specs, pass each flag or argument in its own step before the final run step. Specs should contain the minimal scenarios necessary for complete coverage of the script's features, including every command-line flag and argument. Use a single spec per platform-specific directory (e.g. `osx/spec.md`). If needed, keep script-specific terminology in a `glossary.md` alongside the spec.
 
 ## Unit tests
 - Place tests in a `tests/` directory adjacent to the code.

--- a/portable/vcrunch/spec.md
+++ b/portable/vcrunch/spec.md
@@ -1,5 +1,39 @@
 # vcrunch
 
-## Scenario: transcode video to AV1
-* When I run vcrunch on an MP4 file and specify an output path
-* Then the output file is encoded as AV1
+## Scenario: encode with custom parameters
+* Given an MP4 file "<src>"
+* And an output directory "<out>"
+* When I pass --input "<src>"
+* And I pass --target-size "<size>"
+* And I pass --audio-bitrate "<audio>"
+* And I pass --safety-overhead "<overhead>"
+* And I pass --output-dir "<out>"
+* And I pass --manifest-name "<manifest>"
+* And I pass --name-suffix "<suffix>"
+* And I run vcrunch
+* Then vcrunch creates an AV1 file in "<out>"
+* And the file name ends with "<suffix>.mkv"
+* And "<manifest>" records "<src>" as done
+* And the encode respects the target size
+* And the encode respects the audio bitrate
+* And the encode respects the safety overhead
+
+## Scenario: skip already encoded videos
+* Given an MP4 file "<src>"
+* And "<src>" already encoded into "<out>" with name ending "<suffix>.mkv"
+* And a manifest "<manifest>" in "<out>" marking "<src>" as done
+* When I pass --input "<src>"
+* And I pass --output-dir "<out>"
+* And I pass --manifest-name "<manifest>"
+* And I pass --name-suffix "<suffix>"
+* And I run vcrunch
+* Then vcrunch skips "<src>"
+
+## Scenario: read inputs from a list and filter by glob
+* Given a list file "<list>" containing paths
+* And some paths match "<pattern>" and others do not
+* When I pass --paths-from "<list>"
+* And I pass --pattern "<pattern>"
+* And I run vcrunch
+* Then matching video files are transcoded
+* And non-matching paths are skipped


### PR DESCRIPTION
## Summary
- document that CLI specs must pass each flag in its own step
- split vcrunch scenarios into flag-specific steps for manifest reuse and path-list filtering

## Testing
- `pre-commit run --files AGENTS.md portable/vcrunch/spec.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afa650474c832b800995da5cfde516