### PR TITLE
feat: add portable release tracking

### DIFF
--- a/.github/workflows/release-on-file-change.yml
+++ b/.github/workflows/release-on-file-change.yml
@@ -1,0 +1,87 @@
+name: release-on-file-change
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'portable/**/release.yaml'
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.out.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Find changed services
+        id: out
+        run: |
+          CHANGED=$(git diff --name-only HEAD^ HEAD | grep -E 'portable/.+/release\.yaml' | cut -d/ -f2 | sort -u || true)
+          printf '{"include":[' > m.json
+          for S in $CHANGED; do
+            printf '{"service":"%s"},' "$S" >> m.json
+          done
+          sed -i 's/,$//' m.json || true
+          printf ']}' >> m.json
+          echo "matrix=$(cat m.json)" >> $GITHUB_OUTPUT
+
+  build:
+    needs: plan
+    if: ${{ needs.plan.outputs.matrix != '{"include":[]}' && needs.plan.outputs.matrix != '' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.x' }
+      - name: Install yq
+        run: pip install yq
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Read release.yaml
+        id: rel
+        run: |
+          FILE="portable/${{ matrix.service }}/release.yaml"
+          IMAGE=$(yq -r '.image' "$FILE")
+          VERSION=$(yq -r '.version' "$FILE")
+          echo "image=$IMAGE"   >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Metadata (tags + labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.rel.outputs.image }}
+          tags: |
+            type=raw,value=${{ steps.rel.outputs.version }}
+            type=raw,value=latest
+            type=sha,prefix=
+
+      - name: Build & push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./portable/${{ matrix.service }}
+          file: ./portable/${{ matrix.service }}/Containerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.rel.outputs.version }}
+            VCS_REF=${{ github.sha }}
+            VCS_URL=${{ github.server_url }}/${{ github.repository }}
+
+      - name: (Optional) create namespaced git tag
+        if: ${{ !startsWith( steps.rel.outputs.version, '0.0.0' ) }}
+        run: |
+          git tag "${{ matrix.service }}/${{ steps.rel.outputs.version }}" || true
+          git push origin "${{ matrix.service }}/${{ steps.rel.outputs.version }}" || true

--- a/.github/workflows/require-bump.yml
+++ b/.github/workflows/require-bump.yml
@@ -1,0 +1,47 @@
+name: require-bump
+on:
+  pull_request:
+    paths:
+      - 'portable/**'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.x' }
+      - name: Install yq
+        run: pip install yq semver
+
+      - name: Find touched services
+        id: svc
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth=1
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | cut -d/ -f2 | sort -u | grep -E '^[a-zA-Z0-9_-]+$' || true)
+          echo "list=$CHANGED" >> $GITHUB_OUTPUT
+
+      - name: Verify bumps
+        run: |
+          set -e
+          for SVC in ${{ steps.svc.outputs.list }}; do
+            if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q "^portable/$SVC/" && \
+               git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -vq "^portable/$SVC/release.yaml$"; then
+              OLD=$(git show origin/${{ github.base_ref }}:portable/$SVC/release.yaml | yq -r '.version' || echo "")
+              NEW=$(yq -r '.version' portable/$SVC/release.yaml || echo "")
+              if [[ -z "$OLD" || -z "$NEW" ]]; then
+                echo "Missing release.yaml for $SVC"; exit 1
+              fi
+              OLD=$OLD NEW=$NEW python - <<'PY'
+                import os, sys
+                from semver import VersionInfo
+                old = os.environ["OLD"].lstrip('v')
+                new = os.environ["NEW"].lstrip('v')
+                if VersionInfo.parse(new) <= VersionInfo.parse(old):
+                    print(f"Version not bumped: {new} <= {old}")
+                    sys.exit(1)
+                print(f"OK: {new} > {old}")
+                PY
+            fi
+          done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ This file applies to the entire repository.
    pytest -m integration
    ```
 4. GitHub Actions CI runs `pre-commit run --all-files`, `pytest`, and `pytest -m integration` on all supported platforms.
+5. For portable services, bump the version in `release.yaml` when modifying service code.
 
 Scripts are containerised for cross‑platform use with Podman. Host-specific helpers (e.g. in `osx/`) are only for tasks that do not containerise cleanly.
 

--- a/bin/image-ref
+++ b/bin/image-ref
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+svc="${1:?usage: image-ref <service>}"
+if [[ -f "portable/$svc/release.yaml" ]]; then
+  yq -r '.image + ":" + .version' "portable/$svc/release.yaml"
+else
+  yq -r ".services.\"$svc\" | .image + \":\" + .version" versions.yaml
+fi

--- a/portable/mkiso/Containerfile
+++ b/portable/mkiso/Containerfile
@@ -1,4 +1,10 @@
 FROM python:3.12-alpine
+ARG VERSION
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.opencontainers.image.source="${VCS_URL}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.version="${VERSION}"
 RUN apk add --no-cache cdrkit coreutils
 WORKDIR /app
 COPY script.py /app/mkiso

--- a/portable/mkiso/release.yaml
+++ b/portable/mkiso/release.yaml
@@ -1,0 +1,5 @@
+# single source of truth for this service
+image: docker.io/nashspence/scripts-mkiso
+version: v0.1.0
+labels:
+  org.opencontainers.image.title: mkiso

--- a/portable/qcut/Containerfile
+++ b/portable/qcut/Containerfile
@@ -1,4 +1,10 @@
 FROM python:3.12-alpine
+ARG VERSION
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.opencontainers.image.source="${VCS_URL}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.version="${VERSION}"
 RUN apk add --no-cache ffmpeg libarchive-tools coreutils font-dejavu
 WORKDIR /app
 COPY script.py /app/qcut

--- a/portable/qcut/release.yaml
+++ b/portable/qcut/release.yaml
@@ -1,0 +1,5 @@
+# single source of truth for this service
+image: docker.io/nashspence/scripts-qcut
+version: v0.1.0
+labels:
+  org.opencontainers.image.title: qcut

--- a/portable/stage/Containerfile
+++ b/portable/stage/Containerfile
@@ -1,4 +1,10 @@
 FROM python:3.12-alpine
+ARG VERSION
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.opencontainers.image.source="${VCS_URL}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.version="${VERSION}"
 RUN apk add --no-cache coreutils
 WORKDIR /app
 COPY script.py /app/stage

--- a/portable/stage/release.yaml
+++ b/portable/stage/release.yaml
@@ -1,0 +1,5 @@
+# single source of truth for this service
+image: docker.io/nashspence/scripts-stage
+version: v0.1.0
+labels:
+  org.opencontainers.image.title: stage

--- a/portable/vcrunch/Containerfile
+++ b/portable/vcrunch/Containerfile
@@ -1,4 +1,10 @@
 FROM python:3.12-alpine
+ARG VERSION
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.opencontainers.image.source="${VCS_URL}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.version="${VERSION}"
 RUN apk add --no-cache ffmpeg coreutils
 WORKDIR /app
 COPY script.py /app/vcrunch

--- a/portable/vcrunch/release.yaml
+++ b/portable/vcrunch/release.yaml
@@ -1,0 +1,5 @@
+# single source of truth for this service
+image: docker.io/nashspence/scripts-vcrunch
+version: v0.1.0
+labels:
+  org.opencontainers.image.title: vcrunch


### PR DESCRIPTION
## Summary
- version each portable script via per-directory release.yaml
- add helper to read image references
- auto-build images on release updates and require version bumps in PRs

## Testing
- `pre-commit run --files AGENTS.md portable/mkiso/Containerfile portable/qcut/Containerfile portable/stage/Containerfile portable/vcrunch/Containerfile .github/workflows/release-on-file-change.yml .github/workflows/require-bump.yml bin/image-ref portable/mkiso/release.yaml portable/qcut/release.yaml portable/stage/release.yaml portable/vcrunch/release.yaml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b094863e24832bb4432ef77192c6db