### PR TITLE
Ensure release-on-file-change diff works

### DIFF
--- a/.github/workflows/release-on-file-change.yml
+++ b/.github/workflows/release-on-file-change.yml
@@ -17,6 +17,8 @@ jobs:
       matrix: ${{ steps.out.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
       - name: Find changed services
         id: out
         run: |


### PR DESCRIPTION
## Summary
- ensure release-on-file-change workflow checks out enough history for git diff

## Testing
- `pre-commit run --files .github/workflows/release-on-file-change.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0cbe2e9e8832bbb1d94506afd263b