### PR TITLE
fix: detect untagged releases in release-on-file-change

### DIFF
--- a/.github/workflows/release-on-file-change.yml
+++ b/.github/workflows/release-on-file-change.yml
@@ -19,11 +19,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Find changed services
         id: out
+        env:
+          BASE: ${{ github.event.before }}
         run: |
-          CHANGED=$(git diff --name-only HEAD^ HEAD | grep -E 'portable/.+/release\.yaml' | cut -d/ -f2 | sort -u || true)
+          BASE=${BASE:-HEAD^}
+          CHANGED=$(git diff --name-only "$BASE" HEAD | grep -E 'portable/.+/release\.yaml' | cut -d/ -f2 || true)
+          for F in portable/*/release.yaml; do
+            S=$(cut -d/ -f2 <<<"$F")
+            V=$(grep '^version:' "$F" | awk '{print $2}')
+            if ! git rev-parse -q --verify "refs/tags/$S/$V" >/dev/null; then
+              CHANGED="$CHANGED $S"
+            fi
+          done
+          CHANGED=$(echo "$CHANGED" | tr ' ' '\n' | sort -u)
           printf '{"include":[' > m.json
           for S in $CHANGED; do
             printf '{"service":"%s"},' "$S" >> m.json


### PR DESCRIPTION
## Summary
- detect services without existing git tags and include them in release matrix
- diff changes from previous commit to handle multi-commit pushes

## Testing
- `pre-commit run --files .github/workflows/release-on-file-change.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0cf711cf4832b87bf19256933e278