### PR TITLE
ci: build release images for arm64 and amd64

### DIFF
--- a/.github/workflows/release-on-file-change.yml
+++ b/.github/workflows/release-on-file-change.yml
@@ -54,6 +54,7 @@ jobs:
         with: { python-version: '3.x' }
       - name: Install yq
         run: pip install yq
+      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
@@ -85,6 +86,7 @@ jobs:
         with:
           context: ./portable/${{ matrix.service }}
           file: ./portable/${{ matrix.service }}/Containerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/portable/mkiso/release.yaml
+++ b/portable/mkiso/release.yaml
@@ -1,5 +1,5 @@
 # single source of truth for this service
 image: docker.io/nashspence/scripts-mkiso
-version: v0.1.0
+version: v0.1.1
 labels:
   org.opencontainers.image.title: mkiso

--- a/portable/qcut/release.yaml
+++ b/portable/qcut/release.yaml
@@ -1,5 +1,5 @@
 # single source of truth for this service
 image: docker.io/nashspence/scripts-qcut
-version: v0.1.0
+version: v0.1.1
 labels:
   org.opencontainers.image.title: qcut

--- a/portable/stage/release.yaml
+++ b/portable/stage/release.yaml
@@ -1,5 +1,5 @@
 # single source of truth for this service
 image: docker.io/nashspence/scripts-stage
-version: v0.1.0
+version: v0.1.1
 labels:
   org.opencontainers.image.title: stage

--- a/portable/vcrunch/release.yaml
+++ b/portable/vcrunch/release.yaml
@@ -1,5 +1,5 @@
 # single source of truth for this service
 image: docker.io/nashspence/scripts-vcrunch
-version: v0.1.0
+version: v0.1.1
 labels:
   org.opencontainers.image.title: vcrunch


### PR DESCRIPTION
## Summary
- build release-on-file-change images for both arm64 and amd64
- bump release.yaml versions for portable images to trigger multi-arch releases

## Testing
- `pre-commit run --files portable/stage/release.yaml portable/mkiso/release.yaml portable/qcut/release.yaml portable/vcrunch/release.yaml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0dc3f1488832bab7836a840cf6a8c