### PR TITLE
Fix qcut slot length indexing

### DIFF
--- a/portable/qcut/release.yaml
+++ b/portable/qcut/release.yaml
@@ -1,5 +1,5 @@
 # single source of truth for this service
 image: docker.io/nashspence/scripts-qcut
-version: v0.1.1
+version: v0.1.2
 labels:
   org.opencontainers.image.title: qcut

--- a/portable/qcut/script.py
+++ b/portable/qcut/script.py
@@ -444,7 +444,7 @@ def main():
             d = fi["duration"]
             part = d / qi if qi > 0 else 0.0
             for slot in range(1, qi + 1):
-                Lm = len_slots_min[idx - 1] if (idx - 1) < len_slots_min else args.min
+                Lm = len_slots_min[idx - 1] if (idx - 1) < slot_count else args.min
                 L = float(Lm * 60)
                 ps = (slot - 1) * part
                 mo = max(0.0, part - L)

--- a/portable/qcut/spec.md
+++ b/portable/qcut/spec.md
@@ -1,5 +1,9 @@
 # qcut
 
-## Scenario: extract a clip
-* When I run qcut on a video with a time range and output path
-* Then the clip contains only the selected segment
+## Scenario: auto-edit a directory of videos
+* Given a directory "<src>" containing videos
+* And an output directory "<out>"
+* When I pass --src-dir "<src>"
+* And I pass --autoedit-dir "<out>"
+* And I run qcut
+* Then qcut writes the final video to "<out>"


### PR DESCRIPTION
## Summary
- guard slot length lookup using `slot_count`
- update qcut spec and bump release version

## Testing
- `pre-commit run --files portable/qcut/script.py portable/qcut/spec.md portable/qcut/release.yaml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b119a83a90832b85d2e6a18381e6b3