### PR TITLE
Fix qcut drawtext date overlay parsing

### DIFF
--- a/portable/qcut/release.yaml
+++ b/portable/qcut/release.yaml
@@ -1,5 +1,5 @@
 # single source of truth for this service
 image: docker.io/nashspence/scripts-qcut
-version: v0.1.2
+version: v0.1.3
 labels:
   org.opencontainers.image.title: qcut

--- a/portable/qcut/script.py
+++ b/portable/qcut/script.py
@@ -27,7 +27,8 @@ def log(msg: str):  # timestamped progress logs
 
 VIDEO_EXTS = (".mp4", ".mkv", ".mov", ".m4v", ".MP4", ".MKV", ".MOV", ".M4V")
 DEFAULT_FONT = "/usr/share/fonts/TTF/DejaVuSansMono.ttf"  # present in container
-DATE_FMT_FOR_OVERLAY = r"%m/%d/%Y %H\:%M\:%S"  # escaped colons for drawtext
+# escaped spaces/colons for drawtext filter
+DATE_FMT_FOR_OVERLAY = r"%m/%d/%Y\ %H\:%M\:%S"
 FFCONCAT_HEADER = "ffconcat version 1.0\n"
 MANIFEST_NAME = ".job.json"
 

--- a/portable/qcut/spec.md
+++ b/portable/qcut/spec.md
@@ -7,3 +7,4 @@
 * And I pass --autoedit-dir "<out>"
 * And I run qcut
 * Then qcut writes the final video to "<out>"
+* And the final video shows timestamp overlays


### PR DESCRIPTION
## Summary
- escape spaces in timestamp format for drawtext
- document overlay expectation in spec
- bump qcut version

## Testing
- `pre-commit run --files portable/qcut/script.py portable/qcut/spec.md portable/qcut/release.yaml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b11d23c514832bbe4e0012cbaf509b