### PR TITLE
Rename dr tool to run-podman-script

### DIFF
--- a/osx/bin/run-podman-script
+++ b/osx/bin/run-podman-script
@@ -1,5 +1,5 @@
 #!/bin/zsh
-# dr — build (Podman) and run a Containerfile/Dockerfile; pipe-friendly.
+# run-podman-script — build (Podman) and run a Containerfile/Dockerfile; pipe-friendly.
 # Logs (stderr only): (1) waiting for connection, (2) chosen image + why, (3) exact run command.
 
 set -euo pipefail

--- a/osx/pmachine
+++ b/osx/pmachine
@@ -18,7 +18,7 @@ WRAPPERS_DIR="${WRAPPERS_DIR:-${REPO_DIR}/.wrappers}"
 FILES_DIR="${FILES_DIR:-$REPO_DIR}"
 LA_DIR="$HOME/Library/LaunchAgents"
 UID_NUM="$(id -u)"
-OSXBIN_DIR="${SCRIPT_DIR}/bin"   # REQUIRED (must contain 'dr')
+OSXBIN_DIR="${SCRIPT_DIR}/bin"   # REQUIRED (must contain 'run-podman-script')
 MANIFEST="${WRAPPERS_DIR}/.symlinks-manifest"
 
 MACHINE="${MACHINE:-com.nashspence.pmachine.script}"
@@ -196,17 +196,17 @@ make_name() {
 cat > "$wrapper" <<EOF
 #!/bin/zsh
 set -euo pipefail
-# Auto-generated wrapper. Invokes 'dr' against a specific build file.
+# Auto-generated wrapper. Invokes 'run-podman-script' against a specific build file.
 export DR_WRAPPER_NAME="${name}"
-exec dr "${abs}" "${rel}" "\$@"
+exec run-podman-script "${abs}" "${rel}" "\$@"
 EOF
     else
 cat > "$wrapper" <<EOF
 #!/bin/zsh
 set -euo pipefail
-# Auto-generated wrapper. Invokes 'dr' against a specific build file.
+# Auto-generated wrapper. Invokes 'run-podman-script' against a specific build file.
 export DR_WRAPPER_NAME="${name}"
-exec dr "${abs}" "\$@"
+exec run-podman-script "${abs}" "\$@"
 EOF
     fi
 
@@ -221,10 +221,10 @@ EOF
 }
 
 install_all() {
-  # Require OSXBIN_DIR and dr
-  [[ -d "$OSXBIN_DIR" ]] || die "required directory missing: $OSXBIN_DIR (must contain 'dr')"
-  [[ -f "$OSXBIN_DIR/dr" ]] || die "required tool missing: $OSXBIN_DIR/dr"
-  chmod +x "$OSXBIN_DIR/dr" 2>/dev/null || true
+  # Require OSXBIN_DIR and run-podman-script
+  [[ -d "$OSXBIN_DIR" ]] || die "required directory missing: $OSXBIN_DIR (must contain 'run-podman-script')"
+  [[ -f "$OSXBIN_DIR/run-podman-script" ]] || die "required tool missing: $OSXBIN_DIR/run-podman-script"
+  chmod +x "$OSXBIN_DIR/run-podman-script" 2>/dev/null || true
 
   mkdir -p "$BIN" "$LA_DIR"
 
@@ -315,8 +315,8 @@ install_all() {
   echo "Wrote manifest: $MANIFEST"
 
   case ":$PATH:" in
-    *":$BIN:"*) echo "'dr' is installed at $BIN/dr and is already in your PATH for this shell." ;;
-    *) echo "'dr' is installed at $BIN/dr, but your current shell won't see it until you open a new session."
+    *":$BIN:"*) echo "'run-podman-script' is installed at $BIN/run-podman-script and is already in your PATH for this shell." ;;
+    *) echo "'run-podman-script' is installed at $BIN/run-podman-script, but your current shell won't see it until you open a new session."
        echo "  For this shell only, run: export PATH=\"\$HOME/bin:\$PATH\"" ;;
   esac
 

--- a/osx/pmachine-waker
+++ b/osx/pmachine-waker
@@ -13,7 +13,7 @@ MACHINE="${MACHINE:-com.nashspence.pmachine.script}"
 STATE_DIR="${STATE_DIR:-$HOME/Library/Application Support/pmachine}"
 HOLDS_DIR="$STATE_DIR/holds"              # one file per live connection (by PID)
 STOP_GRACE_SECS="${STOP_GRACE_SECS:-1}"   # small delay before quiesce check
-QUIESCE_MS="${QUIESCE_MS:-1500}"          # keep watching for new holds (back-to-back dr)
+QUIESCE_MS="${QUIESCE_MS:-1500}"          # keep watching for new holds (back-to-back run-podman-script)
 WAIT_TIMEOUT_SECS="${WAIT_TIMEOUT_SECS:-90}"
 
 log() { print -r -- "$(date '+%F %T') pmachine-waker[$$]: $*"; }

--- a/osx/spec.md
+++ b/osx/spec.md
@@ -20,10 +20,10 @@
 * Then the image is written to media with hdiutil
 
 ## Scenario: build and run a Containerfile
-* When I run dr with a directory path
+* When I run run-podman-script with a directory path
 * Then the container builds and runs without affecting the default machine
 
 ## Scenario: run a released container image
 * Given a release.yaml describing a released image
-* When I run dr with a directory path and release.yaml
+* When I run run-podman-script with a directory path and release.yaml
 * Then the released container runs without building


### PR DESCRIPTION
## Summary
- rename `dr` to `run-podman-script`
- update pmachine wrappers and messages for the new name
- adjust waker and spec references

## Testing
- `pre-commit run --files osx/bin/run-podman-script osx/pmachine osx/pmachine-waker osx/spec.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b309a330a0832ba318100efd4c1853