### PR TITLE
refactor: extract installer templates

### DIFF
--- a/osx/install
+++ b/osx/install
@@ -1,8 +1,8 @@
 #!/bin/zsh
-# pmachine: install / uninstall activation + wrapper tooling + brew/podman/machine (pure zsh)
+# install: install / uninstall activation + wrapper tooling + brew/podman/machine (pure zsh)
 # Usage:
-#   ./pmachine                 # Install everything (activation + wrappers + links + brew/podman/machine)
-#   ./pmachine --uninstall     # Remove EVERYTHING this script installed (incl. Podman machine)
+#   ./install                 # Install everything (activation + wrappers + links + brew/podman/machine)
+#   ./install --uninstall     # Remove EVERYTHING this script installed (incl. Podman machine)
 
 set -euo pipefail
 emulate -L zsh
@@ -20,6 +20,11 @@ LA_DIR="$HOME/Library/LaunchAgents"
 UID_NUM="$(id -u)"
 OSXBIN_DIR="${SCRIPT_DIR}/bin"   # REQUIRED (must contain 'run-podman-script')
 MANIFEST="${WRAPPERS_DIR}/.symlinks-manifest"
+
+TEMPLATES_DIR="${SCRIPT_DIR}/templates"
+WRAPPER_TEMPLATE="${TEMPLATES_DIR}/wrapper.zsh"
+WRAPPER_RELEASE_TEMPLATE="${TEMPLATES_DIR}/wrapper-release.zsh"
+SHORTCUTS_TEMPLATE="${TEMPLATES_DIR}/shortcuts_path.zsh"
 
 MACHINE="${MACHINE:-com.nashspence.pmachine.script}"
 PODMAN_CPUS="${PODMAN_CPUS:-10}"
@@ -62,10 +67,7 @@ remove_path_block() {
 
 ensure_shortcuts_snippet() {
   mkdir -p "${SHORTCUTS_SNIPPET:h}"
-  cat > "$SHORTCUTS_SNIPPET" <<'EOS'
-# PATH for macOS Shortcuts "Run Shell Script"
-export PATH="$HOME/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-EOS
+  cp "$SHORTCUTS_TEMPLATE" "$SHORTCUTS_SNIPPET"
   echo "Created Shortcuts PATH snippet: $SHORTCUTS_SNIPPET"
   echo "  In Shortcuts 'Run Shell Script', add as first line:"
   echo "    source \"$SHORTCUTS_SNIPPET\""
@@ -192,24 +194,17 @@ make_name() {
     rel="${cf:h}/release.yaml"
     rel="${rel:A}"
 
+    local tpl
     if [[ -f "$rel" ]]; then
-cat > "$wrapper" <<EOF
-#!/bin/zsh
-set -euo pipefail
-# Auto-generated wrapper. Invokes 'run-podman-script' against a specific build file.
-export DR_WRAPPER_NAME="${name}"
-exec run-podman-script "${abs}" "${rel}" "\$@"
-EOF
+      tpl="$WRAPPER_RELEASE_TEMPLATE"
     else
-cat > "$wrapper" <<EOF
-#!/bin/zsh
-set -euo pipefail
-# Auto-generated wrapper. Invokes 'run-podman-script' against a specific build file.
-export DR_WRAPPER_NAME="${name}"
-exec run-podman-script "${abs}" "\$@"
-EOF
+      tpl="$WRAPPER_TEMPLATE"
     fi
 
+    sed -e "s|%NAME%|${name//&/\\&}|g" \
+        -e "s|%ABS%|${abs//&/\\&}|g" \
+        -e "s|%REL%|${rel//&/\\&}|g" \
+        "$tpl" > "$wrapper"
     chmod +x "$wrapper"
 
     printf '%s\t%s\n' "$name" "$abs" >> "$index_file"
@@ -225,6 +220,10 @@ install_all() {
   [[ -d "$OSXBIN_DIR" ]] || die "required directory missing: $OSXBIN_DIR (must contain 'run-podman-script')"
   [[ -f "$OSXBIN_DIR/run-podman-script" ]] || die "required tool missing: $OSXBIN_DIR/run-podman-script"
   chmod +x "$OSXBIN_DIR/run-podman-script" 2>/dev/null || true
+
+  [[ -f "$SHORTCUTS_TEMPLATE" ]] || die "missing template: $SHORTCUTS_TEMPLATE"
+  [[ -f "$WRAPPER_TEMPLATE" ]] || die "missing template: $WRAPPER_TEMPLATE"
+  [[ -f "$WRAPPER_RELEASE_TEMPLATE" ]] || die "missing template: $WRAPPER_RELEASE_TEMPLATE"
 
   mkdir -p "$BIN" "$LA_DIR"
 

--- a/osx/spec.md
+++ b/osx/spec.md
@@ -1,10 +1,24 @@
 # osx scripts
 
-## Scenario: manage Podman machine wrappers
-* When I run pmachine
-* Then wrappers are installed
-* When I run pmachine --uninstall
-* Then wrappers are removed
+## Scenario: install the Podman machine environment
+* When I run install
+* Then Homebrew is installed
+* And Podman is installed
+* And the pmachine Podman machine exists
+* And wrappers and tools are linked into ~/bin
+* And pmachine-waker launch agent is loaded
+* And ~/bin is added to the shell PATH
+* And a Shortcuts PATH snippet is created
+
+## Scenario: uninstall the Podman machine environment
+* Given install has been run
+* When I pass "--uninstall"
+* And I run install
+* Then wrappers and tools are removed from ~/bin
+* And the launch agent is removed
+* And the Shortcuts PATH snippet is removed
+* And the Podman machine is removed
+* And ~/bin is removed from the shell PATH
 
 ## Scenario: wake the Podman machine on demand
 * Given pmachine-waker is running

--- a/osx/templates/shortcuts_path.zsh
+++ b/osx/templates/shortcuts_path.zsh
@@ -1,0 +1,2 @@
+# PATH for macOS Shortcuts "Run Shell Script"
+export PATH="$HOME/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"

--- a/osx/templates/wrapper-release.zsh
+++ b/osx/templates/wrapper-release.zsh
@@ -1,0 +1,5 @@
+#!/bin/zsh
+set -euo pipefail
+# Auto-generated wrapper. Invokes 'run-podman-script' against a specific build file.
+export DR_WRAPPER_NAME="%NAME%"
+exec run-podman-script "%ABS%" "%REL%" "$@"

--- a/osx/templates/wrapper.zsh
+++ b/osx/templates/wrapper.zsh
@@ -1,0 +1,5 @@
+#!/bin/zsh
+set -euo pipefail
+# Auto-generated wrapper. Invokes 'run-podman-script' against a specific build file.
+export DR_WRAPPER_NAME="%NAME%"
+exec run-podman-script "%ABS%" "$@"


### PR DESCRIPTION
## Summary
- rename `pmachine` installer to `install`
- move wrapper and Shortcuts snippet templates into `osx/templates`
- document install/uninstall features in spec

## Testing
- `pre-commit run --files osx/install osx/spec.md osx/templates/wrapper.zsh osx/templates/wrapper-release.zsh osx/templates/shortcuts_path.zsh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b31998f904832bbb299b7f96c8df84