### PR TITLE
Install Podman Scripts Agent via helper app bundle

### DIFF
--- a/osx/bin/archive-videos
+++ b/osx/bin/archive-videos
@@ -1,7 +1,7 @@
 #!/bin/zsh
 set -euo pipefail
 
-source "$HOME/.config/pmachine/shortcuts_path.zsh"
+source "$HOME/.config/podman-scripts/shortcuts_path.zsh"
 source "$HOME/bin/lib/proc_supervisor.zsh"
 
 INPUT="${1:-}"

--- a/osx/bin/run-podman-script
+++ b/osx/bin/run-podman-script
@@ -9,11 +9,11 @@ log()  { print -u2 -- "$*"; }
 fail() { print -u2 -- "ERROR: $*"; }
 
 # ----- config ----------------------------------------------------------------------------------
-DR_MACHINE="${DR_MACHINE:-${MACHINE:-com.nashspence.pmachine.script}}"
-DR_IMAGE_PREFIX="${DR_IMAGE_PREFIX:-com.nashspence.pmachine.script.}"
+DR_MACHINE="${DR_MACHINE:-${MACHINE:-com.nashspence.scripts}}"
+DR_IMAGE_PREFIX="${DR_IMAGE_PREFIX:-com.nashspence.scripts.}"
 DR_TAG="${DR_TAG:-latest}"
-WAKER_LABEL="${WAKER_LABEL:-com.nashspence.pmachine.script.waker}"
-SOCK="${PMACHINE_SOCK:-/tmp/pmachine.${UID}.sock}"
+WAKER_LABEL="${WAKER_LABEL:-com.nashspence.scripts.agent}"
+SOCK="${PODMAN_SCRIPTS_SOCK:-/tmp/com.nashspence.scripts.${UID}.sock}"
 
 # input: file/dir and optional release.yaml
 file="Containerfile"

--- a/osx/install
+++ b/osx/install
@@ -25,22 +25,34 @@ TEMPLATES_DIR="${SCRIPT_DIR}/templates"
 WRAPPER_TEMPLATE="${TEMPLATES_DIR}/wrapper.zsh"
 WRAPPER_RELEASE_TEMPLATE="${TEMPLATES_DIR}/wrapper-release.zsh"
 SHORTCUTS_TEMPLATE="${TEMPLATES_DIR}/shortcuts_path.zsh"
+LAUNCHER_TEMPLATE="${TEMPLATES_DIR}/launcher.sh"
+INFO_PLIST_TEMPLATE="${TEMPLATES_DIR}/info.plist"
+LAUNCH_AGENT_TEMPLATE="${TEMPLATES_DIR}/launch-agent.plist"
 
-MACHINE="${MACHINE:-com.nashspence.pmachine.script}"
+MACHINE="${MACHINE:-com.nashspence.scripts}"
 PODMAN_CPUS="${PODMAN_CPUS:-10}"
 PODMAN_MEM="${PODMAN_MEM:-18432}"
 PODMAN_DISK="${PODMAN_DISK:-100}"
 
-# ---- Labels / plists -------------------------------------------------------------
-LABEL_WAKER="com.nashspence.pmachine.script.waker"
-PLIST_WAKER_SRC="${SCRIPT_DIR}/${LABEL_WAKER}.plist"
-PLIST_WAKER_DST="${LA_DIR}/${LABEL_WAKER}.plist"
+# ---- Helper bundle / LaunchAgent -------------------------------------------------
+APP_NAME="Podman Scripts Agent"
+BUNDLE_ID="com.nashspence.scripts"
+AGENT_LABEL="${BUNDLE_ID}.agent"
+BASE_DIR="$HOME/Library/Application Support/Nash Spence/Podman Scripts"
+APP_DIR="$BASE_DIR/${APP_NAME}.app"
+CONTENTS="$APP_DIR/Contents"
+MACOS_DIR="$CONTENTS/MacOS"
+RES_DIR="$CONTENTS/Resources"
+INFO_PLIST="$CONTENTS/Info.plist"
+LAUNCHER="$MACOS_DIR/launcher"
+MAIN_SCRIPT="$RES_DIR/podman-scripts-machine-agent"
+PLIST_PATH="${LA_DIR}/${AGENT_LABEL}.plist"
 
 # ---- PATH block markers ----------------------------------------------------------
-PATH_BEGIN_MARK="# >>> pmachine PATH >>>"
-PATH_END_MARK="# <<< pmachine PATH <<<"
+PATH_BEGIN_MARK="# >>> podman-scripts PATH >>>"
+PATH_END_MARK="# <<< podman-scripts PATH <<<"
 PATH_EXPORT_LINE='export PATH="$HOME/bin:$PATH"'
-SHORTCUTS_SNIPPET="$HOME/.config/pmachine/shortcuts_path.zsh"
+SHORTCUTS_SNIPPET="$HOME/.config/podman-scripts/shortcuts_path.zsh"
 
 # ---- Helpers ---------------------------------------------------------------------
 die() { print -u2 -- "ERROR: $*"; exit 1; }
@@ -125,6 +137,44 @@ remove_podman_machine() {
       podman machine rm -f "$MACHINE" >/dev/null 2>&1 || true
     fi
   fi
+}
+
+mk_app_bundle() {
+  mkdir -p "$MACOS_DIR" "$RES_DIR"
+
+  install -m 0755 "$LAUNCHER_TEMPLATE" "$LAUNCHER"
+
+  sed -e "s|%BUNDLE_ID%|${BUNDLE_ID//&/\\&}|g" \
+      -e "s|%APP_NAME%|${APP_NAME//&/\\&}|g" \
+      "$INFO_PLIST_TEMPLATE" > "$INFO_PLIST"
+  chmod 644 "$INFO_PLIST"
+
+  install -m 0755 "$SCRIPT_DIR/podman-scripts-machine-agent" "$MAIN_SCRIPT"
+  codesign -s - --force --deep "$APP_DIR" 2>/dev/null || true
+}
+
+mk_agent_plist() {
+  mkdir -p "$LA_DIR"
+  local sock_path="/tmp/com.nashspence.scripts.${UID_NUM}.sock"
+  sed -e "s|%AGENT_LABEL%|${AGENT_LABEL//&/\\&}|g" \
+      -e "s|%LAUNCHER%|${LAUNCHER//&/\\&}|g" \
+      -e "s|%BUNDLE_ID%|${BUNDLE_ID//&/\\&}|g" \
+      -e "s|%SOCK_PATH%|${sock_path//&/\\&}|g" \
+      -e "s|%MACHINE%|${MACHINE//&/\\&}|g" \
+      -e "s|%LOG_OUT%|${HOME//&/\\&}/Library/Logs/${BUNDLE_ID}.out.log|g" \
+      -e "s|%LOG_ERR%|${HOME//&/\\&}/Library/Logs/${BUNDLE_ID}.err.log|g" \
+      "$LAUNCH_AGENT_TEMPLATE" > "$PLIST_PATH"
+  chmod 644 "$PLIST_PATH"
+}
+
+load_agent() {
+  launchctl bootout gui/$UID_NUM "$PLIST_PATH" >/dev/null 2>&1 || true
+  launchctl bootstrap gui/$UID_NUM "$PLIST_PATH"
+  launchctl kickstart -k gui/$UID_NUM/${AGENT_LABEL} 2>/dev/null || true
+}
+
+unload_agent() {
+  launchctl bootout gui/$UID_NUM "$PLIST_PATH" >/dev/null 2>&1 || true
 }
 
 link_into_bin() {
@@ -224,8 +274,11 @@ install_all() {
   [[ -f "$SHORTCUTS_TEMPLATE" ]] || die "missing template: $SHORTCUTS_TEMPLATE"
   [[ -f "$WRAPPER_TEMPLATE" ]] || die "missing template: $WRAPPER_TEMPLATE"
   [[ -f "$WRAPPER_RELEASE_TEMPLATE" ]] || die "missing template: $WRAPPER_RELEASE_TEMPLATE"
+  [[ -f "$LAUNCHER_TEMPLATE" ]] || die "missing template: $LAUNCHER_TEMPLATE"
+  [[ -f "$INFO_PLIST_TEMPLATE" ]] || die "missing template: $INFO_PLIST_TEMPLATE"
+  [[ -f "$LAUNCH_AGENT_TEMPLATE" ]] || die "missing template: $LAUNCH_AGENT_TEMPLATE"
 
-  mkdir -p "$BIN" "$LA_DIR"
+  mkdir -p "$BIN" "$LA_DIR" "$BASE_DIR"
 
   # 0) Ensure ~/bin in PATH + Shortcuts snippet
   add_path_block "$HOME/.zprofile"
@@ -237,25 +290,17 @@ install_all() {
   ensure_podman
   ensure_podman_machine
 
-  # 1) Copy helper scripts into ~/bin
-  [[ -f "$SCRIPT_DIR/pmachine-waker" ]] || die "missing pmachine-waker next to this script"
-  install -m 0755 "$SCRIPT_DIR/pmachine-waker" "$BIN/pmachine-waker"
+  # 1) Install helper app bundle and LaunchAgent
+  mk_app_bundle
+  mk_agent_plist
+  load_agent
+  echo "Loaded LaunchAgent."
+  echo "Socket: /tmp/com.nashspence.scripts.$UID_NUM.sock (owned by launchd)."
 
-  # 2) Prepare plists
-  [[ -f "$PLIST_WAKER_SRC" ]] || die "missing $PLIST_WAKER_SRC"
-  sed -e "s|%UID%|$UID_NUM|g" -e "s|\${HOME}|$HOME|g" "$PLIST_WAKER_SRC" > "$PLIST_WAKER_DST"
-
-  # 3) (Re)load LaunchAgents
-  launchctl bootout   "gui/$UID_NUM" "$PLIST_WAKER_DST" >/dev/null 2>&1 || true
-  launchctl bootstrap "gui/$UID_NUM" "$PLIST_WAKER_DST"
-
-  echo "Loaded LaunchAgents."
-  echo "Socket: /tmp/pmachine.$UID_NUM.sock (owned by launchd)."
-
-  # 4) Generate wrappers
+  # 2) Generate wrappers
   generate_wrappers
 
-  # 5) Install symlinks (wrappers + tools) tracked by manifest
+  # 3) Install symlinks (wrappers + tools) tracked by manifest
   echo "Installing wrappers from: $WRAPPERS_DIR"
   echo "Installing tools from:    $OSXBIN_DIR"
   echo "Target bin dir:           $BIN"
@@ -363,15 +408,12 @@ uninstall_all() {
     rm -rf "$WRAPPERS_DIR"
   fi
 
-  for label in "$LABEL_WAKER"; do
-    plist="$LA_DIR/$label.plist"
-    launchctl bootout "gui/$UID_NUM" "$plist" >/dev/null 2>&1 || true
-    rm -f "$plist"
-  done
+  unload_agent
+  rm -f "$PLIST_PATH"
+  rm -rf "$APP_DIR"
+  rmdir "$BASE_DIR" 2>/dev/null || true
 
-  rm -f "$BIN/pmachine-waker"
-
-  local sock="/tmp/pmachine.$UID_NUM.sock"
+  local sock="/tmp/com.nashspence.scripts.$UID_NUM.sock"
   [[ -S "$sock" ]] && rm -f "$sock" || true
 
   if [[ -f "$SHORTCUTS_SNIPPET" ]]; then

--- a/osx/podman-scripts-machine-agent
+++ b/osx/podman-scripts-machine-agent
@@ -1,5 +1,5 @@
 #!/bin/zsh
-# pmachine-waker — socket-activated; starts VM, holds while connected, stops if last client disconnects
+# podman-scripts-machine-agent — socket-activated; starts VM, holds while connected, stops if last client disconnects
 
 set -euo pipefail
 emulate -L zsh
@@ -8,15 +8,15 @@ setopt err_return pipefail extended_glob
 export PATH="$HOME/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
 # --- Config ---------------------------------------------------------------------
-MACHINE="${MACHINE:-com.nashspence.pmachine.script}"
+MACHINE="${MACHINE:-com.nashspence.scripts}"
 
-STATE_DIR="${STATE_DIR:-$HOME/Library/Application Support/pmachine}"
+STATE_DIR="${STATE_DIR:-$HOME/Library/Application Support/Nash Spence/Podman Scripts/agent}"
 HOLDS_DIR="$STATE_DIR/holds"              # one file per live connection (by PID)
 STOP_GRACE_SECS="${STOP_GRACE_SECS:-1}"   # small delay before quiesce check
 QUIESCE_MS="${QUIESCE_MS:-1500}"          # keep watching for new holds (back-to-back run-podman-script)
 WAIT_TIMEOUT_SECS="${WAIT_TIMEOUT_SECS:-90}"
 
-log() { print -r -- "$(date '+%F %T') pmachine-waker[$$]: $*"; }
+log() { print -r -- "$(date '+%F %T') podman-scripts-machine-agent[$$]: $*"; }
 
 gc_holds() {
   local f pid

--- a/osx/spec.md
+++ b/osx/spec.md
@@ -4,9 +4,10 @@
 * When I run install
 * Then Homebrew is installed
 * And Podman is installed
-* And the pmachine Podman machine exists
+* And the com.nashspence.scripts Podman machine exists
 * And wrappers and tools are linked into ~/bin
-* And pmachine-waker launch agent is loaded
+* And the Podman Scripts Agent helper app is installed
+* And the Podman Scripts Agent launch agent is loaded
 * And ~/bin is added to the shell PATH
 * And a Shortcuts PATH snippet is created
 
@@ -21,12 +22,12 @@
 * And ~/bin is removed from the shell PATH
 
 ## Scenario: wake the Podman machine on demand
-* Given pmachine-waker is running
+* Given the Podman Scripts Agent is running
 * When I touch the Podman socket
 * Then the machine starts
 
 ## Scenario: stop an idle Podman machine
-* When I run pmachine-idle with a timeout
+* When I run scripts-idle with a timeout
 * Then the machine stops after that timeout
 
 ## Scenario: burn an ISO image

--- a/osx/templates/info.plist
+++ b/osx/templates/info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key><string>%BUNDLE_ID%</string>
+  <key>CFBundleName</key><string>%APP_NAME%</string>
+  <key>CFBundleDisplayName</key><string>%APP_NAME%</string>
+  <key>CFBundleVersion</key><string>1.0</string>
+  <key>CFBundleShortVersionString</key><string>1.0</string>
+  <key>CFBundleExecutable</key><string>launcher</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>LSBackgroundOnly</key><true/>
+</dict>
+</plist>

--- a/osx/templates/launch-agent.plist
+++ b/osx/templates/launch-agent.plist
@@ -2,12 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Label</key><string>com.nashspence.pmachine.script.waker</string>
+  <key>Label</key><string>%AGENT_LABEL%</string>
 
   <key>ProgramArguments</key>
   <array>
-    <string>/bin/zsh</string>
-    <string>${HOME}/bin/pmachine-waker</string>
+    <string>%LAUNCHER%</string>
+  </array>
+
+  <!-- Attribute Background Items to the helper app -->
+  <key>AssociatedBundleIdentifiers</key>
+  <array>
+    <string>%BUNDLE_ID%</string>
   </array>
 
   <!-- launchd owns this socket; it spawns us when a client connects -->
@@ -15,10 +20,10 @@
   <dict>
     <key>Control</key>
     <dict>
-      <key>SockPathName</key><string>/tmp/pmachine.%UID%.sock</string>
+      <key>SockPathName</key><string>%SOCK_PATH%</string>
       <key>SockFamily</key><string>Unix</string>
       <key>SockType</key><string>stream</string>
-      <key>SockMode</key><integer>384</integer> <!-- 0600 -->
+      <key>SockMode</key><integer>384</integer>
     </dict>
   </dict>
 
@@ -30,12 +35,12 @@
 
   <key>EnvironmentVariables</key>
   <dict>
-    <key>MACHINE</key><string>com.nashspence.pmachine.script</string>
+    <key>MACHINE</key><string>%MACHINE%</string>
   </dict>
 
   <key>KeepAlive</key><false/>
   <key>ProcessType</key><string>Background</string>
-  <key>StandardOutPath</key><string>${HOME}/Library/Logs/com.nashspence.pmachine.script.waker.out.log</string>
-  <key>StandardErrorPath</key><string>${HOME}/Library/Logs/com.nashspence.pmachine.script.waker.err.log</string>
+  <key>StandardOutPath</key><string>%LOG_OUT%</string>
+  <key>StandardErrorPath</key><string>%LOG_ERR%</string>
 </dict>
 </plist>

--- a/osx/templates/launcher.sh
+++ b/osx/templates/launcher.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+APP_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+exec "$APP_DIR/Resources/podman-scripts-machine-agent"


### PR DESCRIPTION
## Summary
- rename helper app templates to generic names and update install to use them
- rename the helper's main script to `podman-scripts-machine-agent` and update the launcher
- switch to helper app bundle & LaunchAgent for installing Podman Scripts Agent
- replace remaining `pmachine` references with `com.nashspence.scripts` identifiers and `podman-scripts` config paths
- install Podman Scripts Agent under `~/Library/Application Support/Nash Spence/Podman Scripts`

## Testing
- `pre-commit run --files osx/install osx/podman-scripts-machine-agent osx/spec.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b367b0aa20832ba4fbb0640a35b90a