### PR TITLE
Require flags for run-podman-script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ This file applies to the entire repository.
    pytest -m integration
    ```
 4. GitHub Actions CI runs `pre-commit run --all-files`, `pytest`, and `pytest -m integration` on all supported platforms.
-5. For portable services, update `spec.md`.
+5. For portable services with a `Containerfile`, update `spec.md`. Directories containing only a `release.yaml` do not require a spec.
 
 Scripts are containerised for cross‑platform use with Podman. Host-specific helpers (e.g. in `osx/`) are only for tasks that do not containerise cleanly.
 

--- a/osx/bin/run-podman-script
+++ b/osx/bin/run-podman-script
@@ -15,20 +15,50 @@ DR_TAG="${DR_TAG:-latest}"
 WAKER_LABEL="${WAKER_LABEL:-com.nashspence.scripts.agent}"
 SOCK="${PODMAN_SCRIPTS_SOCK:-/tmp/com.nashspence.scripts.${UID}.sock}"
 
-# input: file/dir and optional release.yaml
-file="Containerfile"
-if [[ -n "${1:-}" ]]; then
-  if [[ -f "$1" && "${1:t}" != "release.yaml" ]]; then
-    file="$1"; shift
-  elif [[ -d "$1" ]]; then
-    file="$1/Containerfile"; shift
-  fi
-fi
+# input flags
+file=""
 release_yaml=""
-if [[ -n "${1:-}" && -f "$1" && "${1:t}" == "release.yaml" ]]; then
-  release_yaml="$1"; shift
+
+typeset -a run_extra cmd_args
+run_extra=()
+while (( $# )); do
+  case "$1" in
+    -f|--file)
+      file="$2"; shift 2 ;;
+    -r|--release)
+      release_yaml="$2"; shift 2 ;;
+    --)
+      shift; break ;;
+    *)
+      run_extra+=("$1"); shift ;;
+  esac
+done
+cmd_args=("$@")
+if (( ${#cmd_args[@]} == 0 )); then
+  integer _anyflag=0
+  for _a in "${run_extra[@]}"; do [[ "$_a" == -* ]] && { _anyflag=1; break; }; done
+  (( !_anyflag )) && { cmd_args=("${run_extra[@]}"); run_extra=(); }
 fi
-[[ -f "$file" ]] || { fail "file not found: $file"; exit 1; }
+
+if [[ -z "$file" && -z "$release_yaml" ]]; then
+  fail "missing --file or --release"; exit 1
+fi
+
+if [[ -n "$file" && -d "$file" ]]; then
+  file="$file/Containerfile"
+fi
+
+if [[ -n "$file" && ! -f "$file" ]]; then
+  fail "file not found: $file"; exit 1
+fi
+
+if [[ -n "$release_yaml" && ! -f "$release_yaml" ]]; then
+  fail "file not found: $release_yaml"; exit 1
+fi
+
+if [[ -z "$file" && -n "$release_yaml" ]]; then
+  file="$release_yaml"
+fi
 
 # ----- hold the launchd socket for our entire lifetime (silent best-effort) --------------------
 typeset -gi DR_SOCK_FD=-1
@@ -82,7 +112,7 @@ wrapper="${DR_WRAPPER_NAME:-}"
 if [[ -z "$wrapper" ]]; then
   dir="$(cd "$(dirname "$file")" && pwd)"; base="${file:t}"
   case "${base:l}" in
-    containerfile|dockerfile) wrapper="${dir:t}" ;;
+    containerfile|dockerfile|release.yaml) wrapper="${dir:t}" ;;
     *) wrapper="$base"
        wrapper="${wrapper%.Containerfile}"; wrapper="${wrapper%.containerfile}"
        wrapper="${wrapper%.Dockerfile}";    wrapper="${wrapper%.dockerfile}"
@@ -106,7 +136,12 @@ fi
 dir="$(cd "$(dirname "$file")" && pwd)"
 
 # ----- choose release image vs build -----------------------------------------------------------
-build_needed=1
+has_containerfile=1
+if [[ "$file" == "$release_yaml" ]]; then
+  has_containerfile=0
+fi
+
+build_needed=$has_containerfile
 image_reason="built locally from '${file}'"
 if [[ -n "$release_yaml" && -z "${DR_NO_PULL:-}" ]]; then
   rel_img="$(yaml_get_key image "$release_yaml")"
@@ -122,7 +157,11 @@ if [[ -n "$release_yaml" && -z "${DR_NO_PULL:-}" ]]; then
       image_reason="release available"
     else
       if is_not_found_err "$pull_err"; then
-        build_needed=1
+        if (( has_containerfile )); then
+          build_needed=1
+        else
+          fail "failed to pull ${rel_ref} (rc=${pull_rc})"; print -u2 -- "$pull_err"; exit $pull_rc
+        fi
       else
         fail "failed to pull ${rel_ref} (rc=${pull_rc}). Details follow:"; print -u2 -- "$pull_err"; exit $pull_rc
       fi
@@ -131,13 +170,17 @@ if [[ -n "$release_yaml" && -z "${DR_NO_PULL:-}" ]]; then
 fi
 
 if (( build_needed )); then
-  set +e
-  podman --connection "$DR_MACHINE" build "${pull_flag[@]}" -f "$file" -t "$local_image" "$dir"
-  build_rc=$?
-  set -e
-  if (( build_rc != 0 )); then fail "build failed (rc=$build_rc) for '${local_image}' from '${file}' (context '${dir}')"; exit $build_rc; fi
-  image="$local_image"
-  image_reason="built locally from '${file}'"
+  if (( has_containerfile )); then
+    set +e
+    podman --connection "$DR_MACHINE" build "${pull_flag[@]}" -f "$file" -t "$local_image" "$dir"
+    build_rc=$?
+    set -e
+    if (( build_rc != 0 )); then fail "build failed (rc=$build_rc) for '${local_image}' from '${file}' (context '${dir}')"; exit $build_rc; fi
+    image="$local_image"
+    image_reason="built locally from '${file}'"
+  else
+    fail "no release image available and no Containerfile to build"; exit 1
+  fi
 fi
 
 # ----- run -------------------------------------------------------------------------------------
@@ -148,10 +191,7 @@ elif [[ -z "${DR_NO_TTY:-}" ]]; then run_flags+=(-t); fi
 env_flags=()
 if [[ ! -t 1 && -z "${DR_NO_UNBUFFER:-}" ]]; then env_flags+=(-e PYTHONUNBUFFERED=1 -e PYTHONIOENCODING=UTF-8); fi
 
-typeset -a run_extra cmd_args; run_extra=()
-while (( $# )); do if [[ "$1" == "--" ]]; then shift; break; fi; run_extra+=("$1"); shift; done
-cmd_args=("$@")
-if (( ${#cmd_args[@]} == 0 )); then integer _anyflag=0; for _a in "${run_extra[@]}"; do [[ "$_a" == -* ]] && { _anyflag=1; break; }; done; (( !_anyflag )) && { cmd_args=("${run_extra[@]}"); run_extra=(); }; fi
+# run flags and command arguments have been parsed above
 
 # (2) minimal image description
 log "${image_reason} -> using ${image}"

--- a/osx/install
+++ b/osx/install
@@ -24,6 +24,7 @@ MANIFEST="${WRAPPERS_DIR}/.symlinks-manifest"
 TEMPLATES_DIR="${SCRIPT_DIR}/templates"
 WRAPPER_TEMPLATE="${TEMPLATES_DIR}/wrapper.zsh"
 WRAPPER_RELEASE_TEMPLATE="${TEMPLATES_DIR}/wrapper-release.zsh"
+WRAPPER_RELEASEONLY_TEMPLATE="${TEMPLATES_DIR}/wrapper-release-only.zsh"
 SHORTCUTS_TEMPLATE="${TEMPLATES_DIR}/shortcuts_path.zsh"
 LAUNCHER_TEMPLATE="${TEMPLATES_DIR}/launcher.zsh"
 INFO_PLIST_TEMPLATE="${TEMPLATES_DIR}/info.plist"
@@ -204,8 +205,8 @@ make_name() {
   local stem slug out i=2
 
   case "${base:l}" in
-    containerfile|dockerfile)
-      # Canonical filename: use the directory as the service name
+    containerfile|dockerfile|release.yaml)
+      # Canonical filenames: use the directory as the service name
       stem="$dir"
       ;;
     *)
@@ -261,6 +262,28 @@ make_name() {
     echo "  + ${name} -> ${abs}"
   done
 
+  # release.yaml-only directories (no Containerfile)
+  local relf
+  for relf in "$FILES_DIR"/portable/**/release.yaml(.N); do
+    [[ -f "$relf" ]] || continue
+    local dir
+    dir="${relf:h}"
+    if [[ -f "$dir/Containerfile" || -f "$dir"/*.Containerfile(.N) || -f "$dir"/*.containerfile(.N) \
+          || -f "$dir/Dockerfile" || -f "$dir"/*.Dockerfile(.N) || -f "$dir"/*.dockerfile(.N) ]]; then
+      continue
+    fi
+    name="$(make_name "$relf")"
+    abs="${relf:A}"
+    wrapper="${WRAPPERS_DIR}/${name}"
+    sed -e "s|%NAME%|${name//&/\\&}|g" \
+        -e "s|%ABS%|${abs//&/\\&}|g" \
+        "$WRAPPER_RELEASEONLY_TEMPLATE" > "$wrapper"
+    chmod +x "$wrapper"
+
+    printf '%s\t%s\n' "$name" "$abs" >> "$index_file"
+    echo "  + ${name} -> ${abs}"
+  done
+
   echo "Wrote index: $index_file"
   echo "Done generating wrappers."
 }
@@ -274,6 +297,7 @@ install_all() {
   [[ -f "$SHORTCUTS_TEMPLATE" ]] || die "missing template: $SHORTCUTS_TEMPLATE"
   [[ -f "$WRAPPER_TEMPLATE" ]] || die "missing template: $WRAPPER_TEMPLATE"
   [[ -f "$WRAPPER_RELEASE_TEMPLATE" ]] || die "missing template: $WRAPPER_RELEASE_TEMPLATE"
+  [[ -f "$WRAPPER_RELEASEONLY_TEMPLATE" ]] || die "missing template: $WRAPPER_RELEASEONLY_TEMPLATE"
   [[ -f "$LAUNCHER_TEMPLATE" ]] || die "missing template: $LAUNCHER_TEMPLATE"
   [[ -f "$INFO_PLIST_TEMPLATE" ]] || die "missing template: $INFO_PLIST_TEMPLATE"
   [[ -f "$LAUNCH_AGENT_TEMPLATE" ]] || die "missing template: $LAUNCH_AGENT_TEMPLATE"

--- a/osx/spec.md
+++ b/osx/spec.md
@@ -35,10 +35,15 @@
 * Then the image is written to media with hdiutil
 
 ## Scenario: build and run a Containerfile
-* When I run run-podman-script with a directory path
+* When I run run-podman-script with "-f" and a directory path
 * Then the container builds and runs without affecting the default machine
 
 ## Scenario: run a released container image
 * Given a release.yaml describing a released image
-* When I run run-podman-script with a directory path and release.yaml
+* When I run run-podman-script with "-f" and a directory path and "-r" and the release.yaml path
+* Then the released container runs without building
+
+## Scenario: run a released container image without a Containerfile
+* Given a release.yaml describing a released image
+* When I run run-podman-script with "-r" and a release.yaml path
 * Then the released container runs without building

--- a/osx/templates/wrapper-release-only.zsh
+++ b/osx/templates/wrapper-release-only.zsh
@@ -1,0 +1,5 @@
+#!/bin/zsh
+set -euo pipefail
+# Auto-generated wrapper. Invokes 'run-podman-script' against a release.yaml only.
+export DR_WRAPPER_NAME="%NAME%"
+exec run-podman-script -r "%ABS%" "$@"

--- a/osx/templates/wrapper-release.zsh
+++ b/osx/templates/wrapper-release.zsh
@@ -2,4 +2,4 @@
 set -euo pipefail
 # Auto-generated wrapper. Invokes 'run-podman-script' against a specific build file.
 export DR_WRAPPER_NAME="%NAME%"
-exec run-podman-script "%ABS%" "%REL%" "$@"
+exec run-podman-script -f "%ABS%" -r "%REL%" "$@"

--- a/osx/templates/wrapper.zsh
+++ b/osx/templates/wrapper.zsh
@@ -2,4 +2,4 @@
 set -euo pipefail
 # Auto-generated wrapper. Invokes 'run-podman-script' against a specific build file.
 export DR_WRAPPER_NAME="%NAME%"
-exec run-podman-script "%ABS%" "$@"
+exec run-podman-script -f "%ABS%" "$@"

--- a/portable/rclone/release.yaml
+++ b/portable/rclone/release.yaml
@@ -1,4 +1,4 @@
 image: docker.io/rclone/rclone
-version: "1.71.0"
+version: "latest"
 labels:
   org.opencontainers.image.title: rclone

--- a/portable/rclone/release.yaml
+++ b/portable/rclone/release.yaml
@@ -1,0 +1,4 @@
+image: docker.io/rclone/rclone
+version: "1.71.0"
+labels:
+  org.opencontainers.image.title: rclone


### PR DESCRIPTION
## Summary
- require explicit `-f`/`-r` flags for `run-podman-script`
- generate release-only wrappers with a dedicated template
- clarify AGENTS guidance and drop unnecessary `spec.md`

## Testing
- `pre-commit run --files AGENTS.md osx/bin/run-podman-script osx/install osx/spec.md osx/templates/wrapper-release.zsh osx/templates/wrapper.zsh osx/templates/wrapper-release-only.zsh`
- `pytest`
- `PATH=/tmp/fakebin:$PATH osx/bin/run-podman-script -r portable/rclone/release.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68b6168c4a54832bb9e49ac113244baa