### PR TITLE
Fix osx install and run-podman-script

### DIFF
--- a/osx/bin/run-podman-script
+++ b/osx/bin/run-podman-script
@@ -134,42 +134,23 @@ fi
   # ----- wait for podman connection (1) -------------------------------------
   wait_podman
 
-# ----- helpers ---------------------------------------------------------------------------------
-slugify(){ local s="${1:l}"; s="${s//[^a-z0-9._-]/-}"; s="${s##-}"; s="${s%%-}"; print -r -- "$s"; }
-yaml_get_key() {
-  local key="$1" yfile="$2"
-  awk -v k="$key" '
-    $0 ~ "^[[:space:]]*"k":" {
-      sub("^[[:space:]]*"k":[[:space:]]*", "", $0)
-      gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0)
-      gsub(/^"[[:space:]]*|"[[:space:]]*$/,"",$0)
-      gsub(/^'\''[[:space:]]*|'\''[[:space:]]*$/,"",$0)
-      print $0
-      exit 0
-    }' "$yfile" 2>/dev/null || true
-}
-is_not_found_err() {
-  local msg="${1:l}"
-  [[ "$msg" == *"manifest unknown"* || "$msg" == *"not found"* || "$msg" == *"no such image"* || "$msg" == *"unknown blob"* || "$msg" == *"error locating image"* ]]
-}
-
-# ----- derive image/tag ------------------------------------------------------------------------
-wrapper="${DR_WRAPPER_NAME:-}"
-if [[ -z "$wrapper" ]]; then
-  dir="$(cd "$(dirname "$file")" && pwd)"; base="${file:t}"
-  case "${base:l}" in
-    containerfile|dockerfile|release.yaml) wrapper="${dir:t}" ;;
-    *) wrapper="$base"
-       wrapper="${wrapper%.Containerfile}"; wrapper="${wrapper%.containerfile}"
-       wrapper="${wrapper%.Dockerfile}";    wrapper="${wrapper%.dockerfile}"
-       wrapper="${wrapper%.*}"
-       [[ -z "$wrapper" ]] && wrapper="${dir:t}" ;;
-  esac
-fi
-wrapper="$(slugify "$wrapper")"
-repo="$(slugify "${DR_IMAGE_PREFIX}${wrapper}")"
-local_image="${repo}:${DR_TAG}"
-image="$local_image"
+  # ----- derive image/tag ---------------------------------------------------
+  wrapper="${DR_WRAPPER_NAME:-}"
+  if [[ -z "$wrapper" ]]; then
+    dir="$(cd "$(dirname "$file")" && pwd)"; base="${file:t}"
+    case "${base:l}" in
+      containerfile|dockerfile|release.yaml) wrapper="${dir:t}" ;;
+      *) wrapper="$base"
+         wrapper="${wrapper%.Containerfile}"; wrapper="${wrapper%.containerfile}"
+         wrapper="${wrapper%.Dockerfile}";    wrapper="${wrapper%.dockerfile}"
+         wrapper="${wrapper%.*}"
+         [[ -z "$wrapper" ]] && wrapper="${dir:t}" ;;
+    esac
+  fi
+  wrapper="$(slugify "$wrapper")"
+  repo="$(slugify "${DR_IMAGE_PREFIX}${wrapper}")"
+  local_image="${repo}:${DR_TAG}"
+  image="$local_image"
 
   local -a pull_flag
   pull_flag=()
@@ -181,54 +162,53 @@ image="$local_image"
     esac
   fi
   dir="$(cd "$(dirname "$file")" && pwd)"
+  # ----- choose release image vs build --------------------------------------
+  has_containerfile=1
+  if [[ "$file" == "$release_yaml" ]]; then
+    has_containerfile=0
+  fi
 
-# ----- choose release image vs build -----------------------------------------------------------
-has_containerfile=1
-if [[ "$file" == "$release_yaml" ]]; then
-  has_containerfile=0
-fi
-
-build_needed=$has_containerfile
-image_reason="built locally from '${file}'"
-if [[ -n "$release_yaml" && -z "${DR_NO_PULL:-}" ]]; then
-  rel_img="$(yaml_get_key image "$release_yaml")"
-  rel_ver="$(yaml_get_key version "$release_yaml")"
-  if [[ -n "$rel_img" && -n "$rel_ver" ]]; then
-    rel_ref="${rel_img}:${rel_ver}"
-    set +e
-    pull_err="$({ podman --connection "$DR_MACHINE" pull "$rel_ref" 1>/dev/null; } 2>&1)"; pull_rc=$?
-    set -e
-    if (( pull_rc == 0 )); then
-      image="$rel_ref"
-      build_needed=0
-      image_reason="release available"
-    else
-      if is_not_found_err "$pull_err"; then
-        if (( has_containerfile )); then
-          build_needed=1
-        else
-          fail "failed to pull ${rel_ref} (rc=${pull_rc})"; print -u2 -- "$pull_err"; exit $pull_rc
-        fi
+  build_needed=$has_containerfile
+  image_reason="built locally from '${file}'"
+  if [[ -n "$release_yaml" && -z "${DR_NO_PULL:-}" ]]; then
+    rel_img="$(yaml_get_key image "$release_yaml")"
+    rel_ver="$(yaml_get_key version "$release_yaml")"
+    if [[ -n "$rel_img" && -n "$rel_ver" ]]; then
+      rel_ref="${rel_img}:${rel_ver}"
+      set +e
+      pull_err="$({ podman --connection "$DR_MACHINE" pull "$rel_ref" 1>/dev/null; } 2>&1)"; pull_rc=$?
+      set -e
+      if (( pull_rc == 0 )); then
+        image="$rel_ref"
+        build_needed=0
+        image_reason="release available"
       else
-        fail "failed to pull ${rel_ref} (rc=${pull_rc}). Details follow:"; print -u2 -- "$pull_err"; exit $pull_rc
+        if is_not_found_err "$pull_err"; then
+          if (( has_containerfile )); then
+            build_needed=1
+          else
+            fail "failed to pull ${rel_ref} (rc=${pull_rc})"; print -u2 -- "$pull_err"; exit $pull_rc
+          fi
+        else
+          fail "failed to pull ${rel_ref} (rc=${pull_rc}). Details follow:"; print -u2 -- "$pull_err"; exit $pull_rc
+        fi
       fi
     fi
   fi
-fi
 
-if (( build_needed )); then
-  if (( has_containerfile )); then
-    set +e
-    podman --connection "$DR_MACHINE" build "${pull_flag[@]}" -f "$file" -t "$local_image" "$dir"
-    build_rc=$?
-    set -e
-    if (( build_rc != 0 )); then fail "build failed (rc=$build_rc) for '${local_image}' from '${file}' (context '${dir}')"; exit $build_rc; fi
-    image="$local_image"
-    image_reason="built locally from '${file}'"
-  else
-    fail "no release image available and no Containerfile to build"; exit 1
+  if (( build_needed )); then
+    if (( has_containerfile )); then
+      set +e
+      podman --connection "$DR_MACHINE" build "${pull_flag[@]}" -f "$file" -t "$local_image" "$dir"
+      build_rc=$?
+      set -e
+      if (( build_rc != 0 )); then fail "build failed (rc=$build_rc) for '${local_image}' from '${file}' (context '${dir}')"; exit $build_rc; fi
+      image="$local_image"
+      image_reason="built locally from '${file}'"
+    else
+      fail "no release image available and no Containerfile to build"; exit 1
+    fi
   fi
-fi
 
   # ----- run ----------------------------------------------------------------
   local -a run_flags env_flags run_extra cmd_args fullcmd
@@ -244,7 +224,7 @@ fi
     env_flags+=(-e PYTHONUNBUFFERED=1 -e PYTHONIOENCODING=UTF-8)
   fi
 
-# run flags and command arguments have been parsed above
+  # run flags and command arguments have been parsed above
 
   # (2) minimal image description
   log "${image_reason} -> using ${image}"

--- a/osx/install
+++ b/osx/install
@@ -29,14 +29,14 @@ main() {
   typeset -g OSXBIN_DIR="${SCRIPT_DIR}/bin"   # must contain run-podman-script
   typeset -g MANIFEST="${WRAPPERS_DIR}/.symlinks-manifest"
 
-TEMPLATES_DIR="${SCRIPT_DIR}/templates"
-WRAPPER_TEMPLATE="${TEMPLATES_DIR}/wrapper.zsh"
-WRAPPER_RELEASE_TEMPLATE="${TEMPLATES_DIR}/wrapper-release.zsh"
-WRAPPER_RELEASEONLY_TEMPLATE="${TEMPLATES_DIR}/wrapper-release-only.zsh"
-SHORTCUTS_TEMPLATE="${TEMPLATES_DIR}/shortcuts_path.zsh"
-LAUNCHER_TEMPLATE="${TEMPLATES_DIR}/launcher.zsh"
-INFO_PLIST_TEMPLATE="${TEMPLATES_DIR}/info.plist"
-LAUNCH_AGENT_TEMPLATE="${TEMPLATES_DIR}/launch-agent.plist"
+  typeset -gr TEMPLATES_DIR="${SCRIPT_DIR}/templates"
+  typeset -gr WRAPPER_TEMPLATE="${TEMPLATES_DIR}/wrapper.zsh"
+  typeset -gr WRAPPER_RELEASE_TEMPLATE="${TEMPLATES_DIR}/wrapper-release.zsh"
+  typeset -gr WRAPPER_RELEASEONLY_TEMPLATE="${TEMPLATES_DIR}/wrapper-release-only.zsh"
+  typeset -gr SHORTCUTS_TEMPLATE="${TEMPLATES_DIR}/shortcuts_path.zsh"
+  typeset -gr LAUNCHER_TEMPLATE="${TEMPLATES_DIR}/launcher.zsh"
+  typeset -gr INFO_PLIST_TEMPLATE="${TEMPLATES_DIR}/info.plist"
+  typeset -gr LAUNCH_AGENT_TEMPLATE="${TEMPLATES_DIR}/launch-agent.plist"
 
   typeset -g MACHINE="${MACHINE:-com.nashspence.scripts}"
   typeset -g PODMAN_CPUS="${PODMAN_CPUS:-10}"


### PR DESCRIPTION
## Summary
- fix path template declarations in osx install script
- clean up run-podman-script merge artifacts and derive image properly

## Testing
- `pre-commit run --files osx/install osx/bin/run-podman-script`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b78aba7c00832b931d16ba2eab085b