### PR TITLE
Rename run-podman-script and support arbitrary Podman subcommands

### DIFF
--- a/osx/bin/podman-script-machine
+++ b/osx/bin/podman-script-machine
@@ -1,6 +1,7 @@
 #!/usr/bin/env zsh
-# run-podman-script — build (Podman) and run a Containerfile/Dockerfile; pipe-friendly.
-# Logs (stderr only): (1) waiting for connection, (2) chosen image + why, (3) exact run command.
+# podman-script-machine — run Podman subcommands against a machine; builds and
+# runs Containerfiles for the `run` subcommand. Pipe-friendly. Logs (stderr
+# only): (1) waiting for connection, (2) chosen image + why, (3) exact command.
 
 set -e
 set -u
@@ -29,50 +30,67 @@ main() {
   local WAKER_LABEL="${WAKER_LABEL:-com.nashspence.podman-machine}"
   local SOCK="${PODMAN_MACHINE_SOCK:-/tmp/com.nashspence.podman-machine.${UID}.sock}"
 
-# input flags
-file=""
-release_yaml=""
+  # ----- podman subcommand ---------------------------------------------------
+  local subcmd="run"
+  if (( $# > 0 )) && [[ "$1" != -* ]]; then
+    subcmd="$1"
+    shift
+  fi
 
-typeset -a run_extra cmd_args
-run_extra=()
-while (( $# )); do
-  case "$1" in
-    -f|--file)
-      file="$2"; shift 2 ;;
-    -r|--release)
-      release_yaml="$2"; shift 2 ;;
-    --)
-      shift; break ;;
-    *)
-      run_extra+=("$1"); shift ;;
-  esac
-done
-cmd_args=("$@")
-if (( ${#cmd_args[@]} == 0 )); then
-  integer _anyflag=0
-  for _a in "${run_extra[@]}"; do [[ "$_a" == -* ]] && { _anyflag=1; break; }; done
-  (( !_anyflag )) && { cmd_args=("${run_extra[@]}"); run_extra=(); }
-fi
+  # ----- run subcommand flags ------------------------------------------------
+  if [[ "$subcmd" == run ]]; then
+    file=""
+    release_yaml=""
 
-if [[ -z "$file" && -z "$release_yaml" ]]; then
-  fail "missing --file or --release"; exit 1
-fi
+    typeset -a raw_args run_extra cmd_args
+    raw_args=("$@")
+    run_extra=()
+    while (( $# )); do
+      case "$1" in
+        -f|--file)
+          file="$2"; shift 2 ;;
+        -r|--release)
+          release_yaml="$2"; shift 2 ;;
+        --)
+          shift; break ;;
+        *)
+          run_extra+=("$1"); shift ;;
+      esac
+    done
+    cmd_args=("$@")
+    if (( ${#cmd_args[@]} == 0 )); then
+      integer _anyflag=0
+      for _a in "${run_extra[@]}"; do [[ "$_a" == -* ]] && { _anyflag=1; break; }; done
+      (( !_anyflag )) && { cmd_args=("${run_extra[@]}"); run_extra=(); }
+    fi
 
-if [[ -n "$file" && -d "$file" ]]; then
-  file="$file/Containerfile"
-fi
+    if [[ -z "$file" && -z "$release_yaml" ]]; then
+      local -a fullcmd
+      fullcmd=(podman --connection "$DR_MACHINE" run "${raw_args[@]}")
+      log "${(j: :)${(q)fullcmd}}"
+      local rc=0
+      set +e
+      "${fullcmd[@]}"; rc=$?
+      set -e
+      exit $rc
+    fi
 
-if [[ -n "$file" && ! -f "$file" ]]; then
-  fail "file not found: $file"; exit 1
-fi
+    if [[ -n "$file" && -d "$file" ]]; then
+      file="$file/Containerfile"
+    fi
 
-if [[ -n "$release_yaml" && ! -f "$release_yaml" ]]; then
-  fail "file not found: $release_yaml"; exit 1
-fi
+    if [[ -n "$file" && ! -f "$file" ]]; then
+      fail "file not found: $file"; exit 1
+    fi
 
-if [[ -z "$file" && -n "$release_yaml" ]]; then
-  file="$release_yaml"
-fi
+    if [[ -n "$release_yaml" && ! -f "$release_yaml" ]]; then
+      fail "file not found: $release_yaml"; exit 1
+    fi
+
+    if [[ -z "$file" && -n "$release_yaml" ]]; then
+      file="$release_yaml"
+    fi
+  fi
 
   # ----- hold the launchd socket for our entire lifetime ---------------------
   typeset -gi DR_SOCK_FD=-1
@@ -133,6 +151,17 @@ fi
 
   # ----- wait for podman connection (1) -------------------------------------
   wait_podman
+
+  if [[ "$subcmd" != run ]]; then
+    local -a fullcmd
+    fullcmd=(podman --connection "$DR_MACHINE" "$subcmd" "$@")
+    log "${(j: :)${(q)fullcmd}}"
+    local rc=0
+    set +e
+    "${fullcmd[@]}"; rc=$?
+    set -e
+    exit $rc
+  fi
 
   # ----- derive image/tag ---------------------------------------------------
   wrapper="${DR_WRAPPER_NAME:-}"

--- a/osx/install
+++ b/osx/install
@@ -25,7 +25,7 @@ main() {
   typeset -g FILES_DIR="${FILES_DIR:-$REPO_DIR}"
   typeset -gr LA_DIR="$HOME/Library/LaunchAgents"
   typeset -gr UID_NUM="$(id -u)"
-  typeset -g OSXBIN_DIR="${SCRIPT_DIR}/bin"   # must contain run-podman-script
+    typeset -g OSXBIN_DIR="${SCRIPT_DIR}/bin"   # must contain podman-script-machine
 
     typeset -gr TEMPLATES_DIR="${SCRIPT_DIR}/templates"
     typeset -gr WRAPPER_TEMPLATE="${TEMPLATES_DIR}/wrapper.zsh"
@@ -292,10 +292,10 @@ main() {
   }
 
   install_all() {
-    # require OSXBIN_DIR and run-podman-script
-    [[ -d "$OSXBIN_DIR" ]] || die "required directory missing: $OSXBIN_DIR (must contain 'run-podman-script')"
-    [[ -f "$OSXBIN_DIR/run-podman-script" ]] || die "required tool missing: $OSXBIN_DIR/run-podman-script"
-    chmod +x "$OSXBIN_DIR/run-podman-script" 2>/dev/null || true
+    # require OSXBIN_DIR and podman-script-machine
+    [[ -d "$OSXBIN_DIR" ]] || die "required directory missing: $OSXBIN_DIR (must contain 'podman-script-machine')"
+    [[ -f "$OSXBIN_DIR/podman-script-machine" ]] || die "required tool missing: $OSXBIN_DIR/podman-script-machine"
+    chmod +x "$OSXBIN_DIR/podman-script-machine" 2>/dev/null || true
 
   [[ -f "$WRAPPER_TEMPLATE" ]] || die "missing template: $WRAPPER_TEMPLATE"
   [[ -f "$WRAPPER_RELEASE_TEMPLATE" ]] || die "missing template: $WRAPPER_RELEASE_TEMPLATE"

--- a/osx/spec.md
+++ b/osx/spec.md
@@ -32,15 +32,24 @@
 * Then the image is written to media with hdiutil
 
 ## Scenario: build and run a Containerfile
-* When I run run-podman-script with "-f" and a directory path
+* When I run podman-script-machine with "run", "-f", and a directory path
 * Then the container builds and runs without affecting the default machine
 
 ## Scenario: run a released container image
 * Given a release.yaml describing a released image
-* When I run run-podman-script with "-f" and a directory path and "-r" and the release.yaml path
+* When I run podman-script-machine with "run", "-f" and a directory path and "-r" and the release.yaml path
 * Then the released container runs without building
 
 ## Scenario: run a released container image without a Containerfile
 * Given a release.yaml describing a released image
-* When I run run-podman-script with "-r" and a release.yaml path
+* When I run podman-script-machine with "run", "-r" and a release.yaml path
 * Then the released container runs without building
+
+## Scenario: run an existing image without build options
+* When I run podman-script-machine with "run" and an image name
+* And I pass a command to execute
+* Then Podman runs the image on the machine without "--file" or "--release"
+
+## Scenario: run another Podman subcommand
+* When I run podman-script-machine with "secret" and "ls"
+* Then Podman lists secrets from the machine

--- a/osx/templates/wrapper-release-only.zsh
+++ b/osx/templates/wrapper-release-only.zsh
@@ -1,5 +1,5 @@
 #!/bin/zsh
 set -euo pipefail
-# Auto-generated wrapper. Invokes 'run-podman-script' against a release.yaml only.
+# Auto-generated wrapper. Invokes 'podman-script-machine run' against a release.yaml only.
 export DR_WRAPPER_NAME="%NAME%"
-exec run-podman-script -r "%ABS%" "$@"
+exec podman-script-machine run -r "%ABS%" "$@"

--- a/osx/templates/wrapper-release.zsh
+++ b/osx/templates/wrapper-release.zsh
@@ -1,5 +1,5 @@
 #!/bin/zsh
 set -euo pipefail
-# Auto-generated wrapper. Invokes 'run-podman-script' against a specific build file.
+# Auto-generated wrapper. Invokes 'podman-script-machine run' against a specific build file.
 export DR_WRAPPER_NAME="%NAME%"
-exec run-podman-script -f "%ABS%" -r "%REL%" "$@"
+exec podman-script-machine run -f "%ABS%" -r "%REL%" "$@"

--- a/osx/templates/wrapper.zsh
+++ b/osx/templates/wrapper.zsh
@@ -1,5 +1,5 @@
 #!/bin/zsh
 set -euo pipefail
-# Auto-generated wrapper. Invokes 'run-podman-script' against a specific build file.
+# Auto-generated wrapper. Invokes 'podman-script-machine run' against a specific build file.
 export DR_WRAPPER_NAME="%NAME%"
-exec run-podman-script -f "%ABS%" "$@"
+exec podman-script-machine run -f "%ABS%" "$@"


### PR DESCRIPTION
## Summary
- rename `run-podman-script` to `podman-script-machine`
- allow running arbitrary Podman subcommands, keeping build logic for `run`
- update wrappers, spec and installer for the new script
- allow plain `podman run` to pass through without requiring `--file` or `--release`

## Testing
- `pre-commit run --files osx/bin/podman-script-machine osx/spec.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8ce53e06c832b8a4503099cb1ef73