### PR TITLE
Add flag to rpush to ignore dotfiles

### DIFF
--- a/osx/bin/rpush
+++ b/osx/bin/rpush
@@ -1,6 +1,6 @@
 #!/bin/zsh
 # Generic Finder-backed network copy/move for macOS (BSD-ish zsh).
-# Usage: rpush <copy|move> <SRC_PATH> <URL>
+# Usage: rpush [--ignore-dotfiles] <copy|move> <SRC_PATH> <URL>
 # URL schemes: smb://  nfs://  http(s):// (WebDAV)
 
 set -e
@@ -13,8 +13,14 @@ main() {
   set -u
   set -o pipefail
 
+  local ignore_dotfiles=0
+  if [[ "${1:-}" == --ignore-dotfiles ]]; then
+    ignore_dotfiles=1
+    shift
+  fi
+
   if (( $# != 3 )); then
-    print -u2 "Usage: $0 <copy|move> <SRC_PATH> <URL>"
+    print -u2 "Usage: $0 [--ignore-dotfiles] <copy|move> <SRC_PATH> <URL>"
     return 64
   fi
 
@@ -42,6 +48,11 @@ main() {
   fi
   if (( is_file && src_has_trailing_slash )); then
     print -u2 "Trailing slash not allowed on file paths: $SRC"
+    return 64
+  fi
+
+  if (( ignore_dotfiles )) && (( ! src_has_trailing_slash || ! is_dir )); then
+    print -u2 "--ignore-dotfiles requires a directory path ending with '/': $SRC"
     return 64
   fi
 
@@ -134,6 +145,7 @@ main() {
     *)             rsync_base=( rsync -aE --progress --human-readable ) ;;
   esac
   [[ "$op" == move ]] && rsync_base+=( --remove-source-files )
+  (( ignore_dotfiles )) && rsync_base+=( '--exclude=.*' )
 
   # ---- Transfer (destination always ends with '/')
   if (( is_file )); then

--- a/osx/spec.md
+++ b/osx/spec.md
@@ -53,3 +53,11 @@
 ## Scenario: run another Podman subcommand
 * When I run podman-script-machine with "secret" and "ls"
 * Then Podman lists secrets from the machine
+
+## Scenario: push directory contents excluding dot files
+* When I run rpush
+* And I pass "--ignore-dotfiles"
+* And I pass "copy"
+* And I pass a directory path ending with "/"
+* And I pass a URL
+* Then dot files are not copied to the destination


### PR DESCRIPTION
## Summary
- add `--ignore-dotfiles` option to `rpush` to skip hidden files when copying a directory's contents
- document the new `rpush` flag in the osx spec

## Testing
- `pre-commit run --files osx/bin/rpush osx/spec.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc0312a9d8832ba501661fb7e8a34d