### PR TITLE
refactor: store launch agent state in data dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,3 @@
 /logs
 node_modules/
 .DS_Store
-/osx/launch-agents/on-mount/state.tsv*
-/osx/launch-agents/on-mount/*.log
-/osx/launch-agents/podman-machine/agent/
-/osx/launch-agents/podman-machine/*.log

--- a/osx/install
+++ b/osx/install
@@ -95,7 +95,7 @@ main() {
     elif [[ -x /usr/local/bin/brew ]]; then
       eval "$(/usr/local/bin/brew shellenv)"
     fi
-    
+
     rehash_safely
     command -v brew >/dev/null 2>&1 || die "brew installation appears to have failed"
   }
@@ -134,8 +134,8 @@ main() {
   }
 
   typeset -A LAUNCH_AGENT_RESOURCES=(
-    [com.nashspence.scripts.on-mount]="state.tsv"
-    [com.nashspence.scripts.podman-machine]="agent"
+    [com.nashspence.scripts.on-mount]="data"
+    [com.nashspence.scripts.podman-machine]="data"
   )
 
   install_launch_agent() {

--- a/osx/launch-agents/on-mount/Scripts - On Mount
+++ b/osx/launch-agents/on-mount/Scripts - On Mount
@@ -5,7 +5,8 @@ marker=".com.nashspence.scripts.on-mount.id"
 onmount_dir="${HOME}/On Mount"
 
 base="$(cd "$(dirname "$0")" && pwd)"
-state="${base}/state.tsv"            # holds: <VolumeName>\t<DeviceID>
+data="${base}/data"
+state="${data}/state.tsv"            # holds: <VolumeName>\t<DeviceID>
 tmp_state="${state}.new"             # temp file for atomic rewrite
 lock="${HOME}/Library/Caches/com.nashspence.scripts.on-mount.lock"
 
@@ -15,7 +16,7 @@ log()   { print -r -- "[$(ts)] $*"; }
 warn()  { print -u2 -r -- "[$(ts)] $*"; }
 
 umask 077
-mkdir -p "${base}"
+mkdir -p "${data}"
 [ -e "${state}" ] || : >| "${state}"  # ensure it exists without truncating
 
 # single-run lock

--- a/osx/launch-agents/on-mount/com.nashspence.scripts.on-mount.plist
+++ b/osx/launch-agents/on-mount/com.nashspence.scripts.on-mount.plist
@@ -8,6 +8,6 @@
   </array>
   <key>StartOnMount</key><true/>
   <key>RunAtLoad</key><true/>
-  <key>StandardOutPath</key><string>%REPO_DIR%/osx/launch-agents/on-mount/stdout.log</string>
-  <key>StandardErrorPath</key><string>%REPO_DIR%/osx/launch-agents/on-mount/stderr.log</string>
+  <key>StandardOutPath</key><string>%REPO_DIR%/osx/launch-agents/on-mount/data/stdout.log</string>
+  <key>StandardErrorPath</key><string>%REPO_DIR%/osx/launch-agents/on-mount/data/stderr.log</string>
 </dict></plist>

--- a/osx/launch-agents/on-mount/data/.gitignore
+++ b/osx/launch-agents/on-mount/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/osx/launch-agents/podman-machine/Scripts - Podman Machine
+++ b/osx/launch-agents/podman-machine/Scripts - Podman Machine
@@ -22,7 +22,7 @@ main() {
   # --- Config ----------------------------------------------------------------
   local MACHINE="${MACHINE:-com.nashspence.scripts}"
 
-  local STATE_DIR="${STATE_DIR:-$REPO_DIR/osx/launch-agents/podman-machine/agent}"
+  local STATE_DIR="${STATE_DIR:-$REPO_DIR/osx/launch-agents/podman-machine/data}"
   local HOLDS_DIR="$STATE_DIR/holds"          # one file per live connection (by PID)
   local STOP_GRACE_SECS="${STOP_GRACE_SECS:-1}"
   local QUIESCE_MS="${QUIESCE_MS:-1500}"      # watch briefly for back-to-back clients

--- a/osx/launch-agents/podman-machine/com.nashspence.scripts.podman-machine.plist
+++ b/osx/launch-agents/podman-machine/com.nashspence.scripts.podman-machine.plist
@@ -32,6 +32,6 @@
 
   <key>KeepAlive</key><false/>
   <key>ProcessType</key><string>Background</string>
-  <key>StandardOutPath</key><string>%REPO_DIR%/osx/launch-agents/podman-machine/stdout.log</string>
-  <key>StandardErrorPath</key><string>%REPO_DIR%/osx/launch-agents/podman-machine/stderr.log</string>
+  <key>StandardOutPath</key><string>%REPO_DIR%/osx/launch-agents/podman-machine/data/stdout.log</string>
+  <key>StandardErrorPath</key><string>%REPO_DIR%/osx/launch-agents/podman-machine/data/stderr.log</string>
 </dict></plist>

--- a/osx/launch-agents/podman-machine/data/.gitignore
+++ b/osx/launch-agents/podman-machine/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- store on-mount state and logs under a dedicated data directory
- move podman-machine runtime files and logs under data
- update install script to clean up new data directories

## Testing
- `pre-commit run --files .gitignore osx/install 'osx/launch-agents/on-mount/Scripts - On Mount' osx/launch-agents/on-mount/com.nashspence.scripts.on-mount.plist 'osx/launch-agents/podman-machine/Scripts - Podman Machine' osx/launch-agents/podman-machine/com.nashspence.scripts.podman-machine.plist osx/launch-agents/on-mount/data/.gitignore osx/launch-agents/podman-machine/data/.gitignore`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc06fc5f9c832b886ca7d87b9c7203