### PR TITLE
stage: add verbose logging

### DIFF
--- a/portable/stage/spec.md
+++ b/portable/stage/spec.md
@@ -3,3 +3,12 @@
 ## Scenario: stage files into a manifest
 * When I run stage with an input directory and manifest path
 * Then the manifest lists the staged files
+
+## Scenario: verbose logging
+* Given a file "<src>"
+* And an output directory "<out>"
+* When I pass --input "<src>"
+* And I pass --dest-dir "<out>"
+* And I pass --verbose
+* And I run stage
+* Then "created" is printed to stderr


### PR DESCRIPTION
## Summary
- add a debug logger and `--verbose` flag to stage for opt-in detailed logging
- document verbose mode in stage spec

## Testing
- `pre-commit run --files portable/stage/script.py portable/stage/spec.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc0aec496c832baf9b06a23c28427a