### PR TITLE
mkiso: add optional verbose logging

### DIFF
--- a/portable/mkiso/spec.md
+++ b/portable/mkiso/spec.md
@@ -3,3 +3,7 @@
 ## Scenario: build an ISO image
 * When I run mkiso with an input directory and output file
 * Then the output file is created
+
+## Scenario: verbose logging
+* When I run mkiso with an input directory and output file and verbose mode
+* Then the output file is created


### PR DESCRIPTION
## Summary
- add `--verbose` flag to mkiso for detailed diagnostics
- streamline default logging to a single concise status line without `[mkiso]`
- document verbose mode in mkiso spec

## Testing
- `pre-commit run --files portable/mkiso/script.py portable/mkiso/spec.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc0ace5768832b9203482b84b6fd51