### PR TITLE
Rename podman-scripts-machine and streamline logging

### DIFF
--- a/osx/bin/podman-scripts-machine
+++ b/osx/bin/podman-scripts-machine
@@ -1,7 +1,8 @@
 #!/usr/bin/env zsh
-# podman-script-machine — run Podman subcommands against a machine; builds and
-# runs Containerfiles for the `run` subcommand. Pipe-friendly. Logs (stderr
-# only): (1) waiting for connection, (2) chosen image + why, (3) exact command.
+# podman-scripts-machine — run Podman subcommands against a machine; builds and
+# runs Containerfiles for the `run` subcommand. Pipe-friendly. By default, only
+# the full Podman command is logged to stderr; pass `--verbose` for detailed
+# debug logging including connection waits and image selection.
 
 set -e
 set -u
@@ -14,9 +15,19 @@ main() {
   set -u
   set -o pipefail
 
-  # ----- minimal logging (stderr only) ---------------------------------------
-  log()  { print -u2 -- "$*"; }
-  fail() { print -u2 -- "ERROR: $*"; }
+  local verbose=0
+  while (( $# )); do
+    case "$1" in
+      --verbose) verbose=1; shift ;;
+      --) shift; break ;;
+      *) break ;;
+    esac
+  done
+
+  # ----- logging (stderr only) ----------------------------------------------
+  log()   { (( verbose )) && print -u2 -- "$*"; }
+  cmdlog(){ print -u2 -- "$*"; }
+  fail()  { print -u2 -- "ERROR: $*"; }
 
   # ----- deps ----------------------------------------------------------------
   for c in podman awk date; do
@@ -67,7 +78,7 @@ main() {
     if [[ -z "$file" && -z "$release_yaml" ]]; then
       local -a fullcmd
       fullcmd=(podman --connection "$DR_MACHINE" run "${raw_args[@]}")
-      log "${(j: :)${(q)fullcmd}}"
+      cmdlog "${(j: :)${(q)fullcmd}}"
       local rc=0
       set +e
       "${fullcmd[@]}"; rc=$?
@@ -155,7 +166,7 @@ main() {
   if [[ "$subcmd" != run ]]; then
     local -a fullcmd
     fullcmd=(podman --connection "$DR_MACHINE" "$subcmd" "$@")
-    log "${(j: :)${(q)fullcmd}}"
+    cmdlog "${(j: :)${(q)fullcmd}}"
     local rc=0
     set +e
     "${fullcmd[@]}"; rc=$?
@@ -260,7 +271,7 @@ main() {
 
   # Compose exact command and log it (3)
   fullcmd=(podman --connection "$DR_MACHINE" run --rm "${run_flags[@]}" "${env_flags[@]}" "${run_extra[@]}" "$image" "${cmd_args[@]}")
-  log "${(j: :)${(q)fullcmd}}"
+  cmdlog "${(j: :)${(q)fullcmd}}"
 
   # ----- execute with signal translation (INT then KILL) --------------------
   setopt TRAPS_ASYNC

--- a/osx/install
+++ b/osx/install
@@ -25,7 +25,7 @@ main() {
   typeset -g FILES_DIR="${FILES_DIR:-$REPO_DIR}"
   typeset -gr LA_DIR="$HOME/Library/LaunchAgents"
   typeset -gr UID_NUM="$(id -u)"
-  typeset -g OSXBIN_DIR="${SCRIPT_DIR}/bin"   # must contain podman-script-machine
+  typeset -g OSXBIN_DIR="${SCRIPT_DIR}/bin"   # must contain podman-scripts-machine
 
   typeset -gr TEMPLATES_DIR="${SCRIPT_DIR}/templates"
   typeset -gr WRAPPER_TEMPLATE="${TEMPLATES_DIR}/wrapper.zsh"
@@ -291,10 +291,10 @@ main() {
   }
 
   install_all() {
-    # require OSXBIN_DIR and podman-script-machine
-    [[ -d "$OSXBIN_DIR" ]] || die "required directory missing: $OSXBIN_DIR (must contain 'podman-script-machine')"
-    [[ -f "$OSXBIN_DIR/podman-script-machine" ]] || die "required tool missing: $OSXBIN_DIR/podman-script-machine"
-    chmod +x "$OSXBIN_DIR/podman-script-machine" 2>/dev/null || true
+    # require OSXBIN_DIR and podman-scripts-machine
+    [[ -d "$OSXBIN_DIR" ]] || die "required directory missing: $OSXBIN_DIR (must contain 'podman-scripts-machine')"
+    [[ -f "$OSXBIN_DIR/podman-scripts-machine" ]] || die "required tool missing: $OSXBIN_DIR/podman-scripts-machine"
+    chmod +x "$OSXBIN_DIR/podman-scripts-machine" 2>/dev/null || true
 
     [[ -f "$WRAPPER_TEMPLATE" ]] || die "missing template: $WRAPPER_TEMPLATE"
     [[ -f "$WRAPPER_RELEASE_TEMPLATE" ]] || die "missing template: $WRAPPER_RELEASE_TEMPLATE"

--- a/osx/spec.md
+++ b/osx/spec.md
@@ -32,27 +32,31 @@
 * Then the image is written to media with hdiutil
 
 ## Scenario: build and run a Containerfile
-* When I run podman-script-machine with "run", "-f", and a directory path
+* When I run podman-scripts-machine with "run", "-f", and a directory path
 * Then the container builds and runs without affecting the default machine
 
 ## Scenario: run a released container image
 * Given a release.yaml describing a released image
-* When I run podman-script-machine with "run", "-f" and a directory path and "-r" and the release.yaml path
+* When I run podman-scripts-machine with "run", "-f" and a directory path and "-r" and the release.yaml path
 * Then the released container runs without building
 
 ## Scenario: run a released container image without a Containerfile
 * Given a release.yaml describing a released image
-* When I run podman-script-machine with "run", "-r" and a release.yaml path
+* When I run podman-scripts-machine with "run", "-r" and a release.yaml path
 * Then the released container runs without building
 
 ## Scenario: run an existing image without build options
-* When I run podman-script-machine with "run" and an image name
+* When I run podman-scripts-machine with "run" and an image name
 * And I pass a command to execute
 * Then Podman runs the image on the machine without "--file" or "--release"
 
 ## Scenario: run another Podman subcommand
-* When I run podman-script-machine with "secret" and "ls"
+* When I run podman-scripts-machine with "secret" and "ls"
 * Then Podman lists secrets from the machine
+
+## Scenario: enable verbose logging
+* When I run podman-scripts-machine with "--verbose", "run" and an image name
+* Then detailed debug logs are printed
 
 ## Scenario: push directory contents excluding dot files
 * When I run rpush

--- a/osx/templates/wrapper-release-only.zsh
+++ b/osx/templates/wrapper-release-only.zsh
@@ -1,5 +1,5 @@
 #!/bin/zsh
 set -euo pipefail
-# Auto-generated wrapper. Invokes 'podman-script-machine run' against a release.yaml only.
+# Auto-generated wrapper. Invokes 'podman-scripts-machine run' against a release.yaml only.
 export DR_WRAPPER_NAME="%NAME%"
-exec podman-script-machine run -r "%ABS%" "$@"
+exec podman-scripts-machine run -r "%ABS%" "$@"

--- a/osx/templates/wrapper-release.zsh
+++ b/osx/templates/wrapper-release.zsh
@@ -1,5 +1,5 @@
 #!/bin/zsh
 set -euo pipefail
-# Auto-generated wrapper. Invokes 'podman-script-machine run' against a specific build file.
+# Auto-generated wrapper. Invokes 'podman-scripts-machine run' against a specific build file.
 export DR_WRAPPER_NAME="%NAME%"
-exec podman-script-machine run -f "%ABS%" -r "%REL%" "$@"
+exec podman-scripts-machine run -f "%ABS%" -r "%REL%" "$@"

--- a/osx/templates/wrapper.zsh
+++ b/osx/templates/wrapper.zsh
@@ -1,5 +1,5 @@
 #!/bin/zsh
 set -euo pipefail
-# Auto-generated wrapper. Invokes 'podman-script-machine run' against a specific build file.
+# Auto-generated wrapper. Invokes 'podman-scripts-machine run' against a specific build file.
 export DR_WRAPPER_NAME="%NAME%"
-exec podman-script-machine run -f "%ABS%" "$@"
+exec podman-scripts-machine run -f "%ABS%" "$@"


### PR DESCRIPTION
## Summary
- rename script to `podman-scripts-machine` and update references
- add `--verbose` flag that emits debug logs while default output shows only the full podman command
- refresh wrapper templates, installer, and spec for new name and logging

## Testing
- `pre-commit run --files osx/bin/podman-scripts-machine osx/install osx/spec.md osx/templates/wrapper.zsh osx/templates/wrapper-release.zsh osx/templates/wrapper-release-only.zsh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc11c1a3d8832b9f66e7580378aef8