### PR TITLE
refactor: manage PATH via lib

### DIFF
--- a/osx/install
+++ b/osx/install
@@ -49,7 +49,8 @@ main() {
   # ---- PATH block markers ---------------------------------------------------
   typeset -gr PATH_BEGIN_MARK="# >>> podman-scripts PATH >>>"
   typeset -gr PATH_END_MARK="# <<< podman-scripts PATH <<<"
-  typeset -gr PATH_EXPORT_LINE="export PATH=\"${WRAPPERS_DIR}:${OSXBIN_DIR}:\$PATH\""
+  typeset -gr EXPORT_REPO_LINE="export PODMAN_SCRIPTS_DIR=\"${REPO_DIR}\""
+  typeset -gr SOURCE_LIB_LINE='source "$PODMAN_SCRIPTS_DIR/osx/lib.sh"'
 
   # ---- Helpers --------------------------------------------------------------
   die() { print -u2 -- "ERROR: $*"; exit 1; }
@@ -61,7 +62,8 @@ main() {
     if ! grep -Fqx -- "$PATH_BEGIN_MARK" "$file" 2>/dev/null; then
       {
         printf '\n%s\n' "$PATH_BEGIN_MARK"
-        printf '%s\n' "$PATH_EXPORT_LINE"
+        printf '%s\n' "$EXPORT_REPO_LINE"
+        printf '%s\n' "$SOURCE_LIB_LINE"
         printf '%s\n' "$PATH_END_MARK"
       } >> "$file"
       echo "  + added PATH block to ${file##$HOME/}"

--- a/osx/lib.sh
+++ b/osx/lib.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env zsh
+
+# Adjust PATH using the repository directory provided in PODMAN_SCRIPTS_DIR.
+
+# Skip if the variable is unset.
+[[ -n "${PODMAN_SCRIPTS_DIR:-}" ]] || return 0
+
+export PATH="${PODMAN_SCRIPTS_DIR}/.wrappers:${PODMAN_SCRIPTS_DIR}/osx/bin:$PATH"


### PR DESCRIPTION
## Summary
- set `PODMAN_SCRIPTS_DIR` in shell init and source `osx/lib.sh`
- add library to update PATH based on repository location

## Testing
- `pre-commit run --files osx/install osx/lib.sh`
- `pytest` *(fails: AttributeError: module 'portable.vcrunch.script' has no attribute 'run')*

------
https://chatgpt.com/codex/tasks/task_e_68c4a3237ce4832b878325f4a5bb2936