### PR TITLE
Enable mypy for mkiso and fix typing

### DIFF
--- a/portable/mkiso/tests/test_mkiso.py
+++ b/portable/mkiso/tests/test_mkiso.py
@@ -1,15 +1,16 @@
 """Tests for mkiso script."""
 
-# mypy: ignore-errors
-
 import sys
 from pathlib import Path
+from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 import portable.mkiso.script as script  # noqa: E402
 
 
-def test_stdout_is_output_filename(tmp_path, monkeypatch, capsys):
+def test_stdout_is_output_filename(
+    tmp_path: Path, monkeypatch: Any, capsys: Any
+) -> None:
     src_dir = tmp_path / "src"
     src_dir.mkdir()
     (src_dir / "a.txt").write_text("hi")


### PR DESCRIPTION
## Summary
- enable strict mypy checking for mkiso
- annotate mkiso script and tests

## Testing
- `pre-commit run --files portable/mkiso/script.py portable/mkiso/tests/test_mkiso.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4a955f6ac832bb21c11160b3c92b6