### PR TITLE
Add minimal macOS keychain wrapper script

### DIFF
--- a/osx/bin/kc
+++ b/osx/bin/kc
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Minimal Keychain wrapper
+
+set -eu
+
+usage() {
+    printf 'Usage: %s {add|update|get} <name>\n' "${0##*/}" >&2
+    exit 2
+}
+
+cmd=${1:-}
+name=${2:-}
+
+[ -n "$cmd" ] && [ -n "$name" ] || usage
+
+service="com.nashspence.scripts.kc.$name"
+
+case "$cmd" in
+    add)
+        pw=$(pbpaste)
+        security add-generic-password -a "$USER" -s "$service" -w "$pw"
+        ;;
+    update)
+        pw=$(pbpaste)
+        security add-generic-password -U -a "$USER" -s "$service" -w "$pw"
+        ;;
+    get)
+        security find-generic-password -s "$service" -w
+        ;;
+    *)
+        usage
+        ;;
+esac

--- a/osx/spec.md
+++ b/osx/spec.md
@@ -65,3 +65,16 @@
 * And I pass a directory path ending with "/"
 * And I pass a URL
 * Then dot files are not copied to the destination
+
+## Scenario: store and retrieve a Keychain password
+* Given a password is on the clipboard
+* When I run kc with "add"
+* And I pass a name
+* Then the password is stored under that name
+* When I run kc with "get"
+* And I pass the same name
+* Then the password is printed
+* Given another password is on the clipboard
+* When I run kc with "update"
+* And I pass the same name
+* Then the password is updated


### PR DESCRIPTION
## Summary
- add kc script to store, update, and fetch Keychain passwords using the clipboard
- document kc usage in osx/spec.md

## Testing
- `pre-commit run --files osx/bin/kc osx/spec.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4b78a63dc832bb67588d0f0028f7a