### PR TITLE
refactor: replace zsh scripts with POSIX sh

### DIFF
--- a/osx/bin/archive-record
+++ b/osx/bin/archive-record
@@ -1,28 +1,27 @@
-#!/usr/bin/env zsh
+#!/bin/sh
 
-set -e
-set -u
-set -o pipefail
-[[ -n "${DEBUG:-}" ]] && set -x
+set -eu
+[ -n "${DEBUG:-}" ] && set -x
+
+die() {
+  printf '%s\n' "$*" >&2
+  exit 2
+}
 
 main() {
-  emulate -L zsh
-  set -e
-  set -u
-  set -o pipefail
+  shortcuts="$HOME/.config/podman-scripts/shortcuts_path.zsh"
+  [ -r "$shortcuts" ] || die "Missing shortcuts file: $shortcuts"
 
-  local shortcuts="$HOME/.config/podman-scripts/shortcuts_path.zsh"
-  [[ -r "$shortcuts" ]] || die "Missing shortcuts file: $shortcuts"
-
+  # shellcheck source=/dev/null  # dynamic user config path
   . "$shortcuts"
 
-  local src="${1:-}"
-  [[ -n "$src" ]] || die "No input directory path provided"
-  [[ -r "$src" ]] || die "Input not readable: $src"
+  src="${1:-}"
+  [ -n "$src" ] || die "No input directory path provided"
+  [ -r "$src" ] || die "Input not readable: $src"
 
-  local rname="${2:-}"
-  [[ -n "$rname" ]] || die "No record name provided"
-  [[ -r "$rname" ]] || die "Record name not readable: $rname"
+  rname="${2:-}"
+  [ -n "$rname" ] || die "No record name provided"
+  [ -r "$rname" ] || die "Record name not readable: $rname"
 
   command -v caffeinate >/dev/null 2>&1 || die "caffeinate not found"
   command -v birthrname >/dev/null 2>&1 || die "birthrname not found"
@@ -32,7 +31,5 @@ main() {
   birthrname "$src"
   rpush move "$src/" "smb://0819870.xyz/convert/$rname/"
 }
-
-die() { print -u2 -- "$@"; exit 2; }
 
 main "$@"

--- a/osx/bin/archive-videos
+++ b/osx/bin/archive-videos
@@ -1,23 +1,37 @@
-#!/usr/bin/env zsh
+#!/bin/sh
 # Pipeline driver: stage -> vcrunch -> ( mkiso & qcut ) -> burniso -> wait qcut
 # Usage:
 #   archive-videos /path/to/input                     # output: $PWD/$(date -u +%Y%m%dT%H%M%SZ)
 #   archive-videos /path/to/input /custom/output/dir  # output: /custom/output/dir
 
-set -e
-set -u
-set -o pipefail
-[[ -n "${DEBUG:-}" ]] && set -x
+set -eu
+[ -n "${DEBUG:-}" ] && set -x
+
+die() {
+  printf '%s\n' "$*" >&2
+  exit 2
+}
+
+kill_if_running() {
+  pid=${1:-}
+  [ -n "$pid" ] || return 0
+  kill -0 "$pid" 2>/dev/null || return 0
+  kill "$pid" 2>/dev/null || true
+}
+
+cleanup() {
+  for p in "$@"; do
+    kill_if_running "$p"
+  done
+  for p in "$@"; do
+    [ -n "$p" ] && wait "$p" 2>/dev/null || true
+  done
+}
 
 main() {
-  emulate -L zsh
-  set -e
-  set -u
-  set -o pipefail
-
-  local input="${1:-}"
-  [[ -n "$input" ]] || die "No input file path provided"
-  [[ -r "$input" ]] || die "Input not readable: $input"
+  input=${1:-}
+  [ -n "$input" ] || die "No input file path provided"
+  [ -r "$input" ] || die "Input not readable: $input"
 
   command -v caffeinate >/dev/null 2>&1 || die "caffeinate not found"
   command -v burniso    >/dev/null 2>&1 || die "burniso not found"
@@ -27,11 +41,9 @@ main() {
   command -v qcut       >/dev/null 2>&1 || die "qcut not found"
   command -v rpush      >/dev/null 2>&1 || die "rpush not found"
 
-  local now out stage_out vcrunch_out mkiso_out qcut_out
-  now="$(date -u +%Y%m%dT%H%M%SZ)"
+  now=$(date -u +%Y%m%dT%H%M%SZ)
 
-  # If $2 provided, use it; else default to CWD/$now
-  out="${2:-$PWD/$now}"
+  out=${2:-"$PWD/$now"}
 
   stage_out="$out/stage"
   vcrunch_out="$out/vcrunch"
@@ -39,67 +51,38 @@ main() {
   qcut_out="$out/qcut"
   mkdir -p -- "$stage_out" "$vcrunch_out" "$mkiso_out" "$qcut_out"
 
-  # Keep Mac awake until this PID exits (caffeinate exits automatically).
   caffeinate -dims -w $$ &
 
-  # Ensure background jobs are cleaned up on signals.
-  local mkiso_pid="" qcut_pid=""
+  mkiso_pid=
+  qcut_pid=
   trap 'cleanup "$mkiso_pid" "$qcut_pid"; exit 130' INT
   trap 'cleanup "$mkiso_pid" "$qcut_pid"; exit 143' TERM HUP QUIT
 
-  # --- sequential steps ---
-  stage   -v "${input}:/in"       -v "${stage_out}:/out"
-  vcrunch -v "${stage_out}:/in"   -v "${vcrunch_out}:/out"
+  stage   -v "${input}:/in"     -v "${stage_out}:/out"
+  vcrunch -v "${stage_out}:/in" -v "${vcrunch_out}:/out"
 
-  # --- parallel steps ---
-  mkiso -v "${vcrunch_out}:/in"   -v "${mkiso_out}:/out" -- --out-file "${now}.iso" &
+  mkiso -v "${vcrunch_out}:/in" -v "${mkiso_out}:/out" -- --out-file "${now}.iso" &
   mkiso_pid=$!
-  qcut  -v "${stage_out}:/in"     -v "${qcut_out}:/out" &
+  qcut  -v "${stage_out}:/in"   -v "${qcut_out}:/out" &
   qcut_pid=$!
 
-  # Wait for mkiso first; on failure, cancel qcut and exit with mkiso's code.
   if ! wait "$mkiso_pid"; then
-    local rc=$?
+    rc=$?
     kill_if_running "$qcut_pid"
     wait "$qcut_pid" 2>/dev/null || true
-    exit $rc
+    exit "$rc"
   fi
 
-  # Burn ISO; on failure, also cancel qcut and propagate burniso's status.
   if ! burniso -v "${mkiso_out}/${now}.iso"; then
-    local rc=$?
+    rc=$?
     kill_if_running "$qcut_pid"
     wait "$qcut_pid" 2>/dev/null || true
-    exit $rc
+    exit "$rc"
   fi
 
-  # Let qcut finish; propagate its status.
   wait "$qcut_pid"
 
-  # Send qcut output to SMB share
   rpush copy "${qcut_out}/" "smb://0819870.xyz/shared/family/daily/"
-}
-
-# ---- helpers ---------------------------------------------------------------
-
-die() { print -u2 -- "$@"; exit 2; }
-
-kill_if_running() {
-  local pid="${1:-}"
-  [[ -n "$pid" ]] || return 0
-  kill -0 "$pid" 2>/dev/null || return 0
-  kill "$pid" 2>/dev/null || true
-}
-
-cleanup() {
-  # best-effort termination of provided PIDs
-  local p
-  for p in "$@"; do
-    kill_if_running "$p"
-  done
-  for p in "$@"; do
-    [[ -n "$p" ]] && wait "$p" 2>/dev/null || true
-  done
 }
 
 main "$@"

--- a/osx/bin/birthrname
+++ b/osx/bin/birthrname
@@ -1,68 +1,56 @@
-#!/bin/zsh
+#!/bin/sh
 # Rename files in a directory by prefixing their creation time (APFS "birth time")
 # Format: YYYY-mm-ddTHH_MM_SS±ZZZZ!~filename[~N][.ext]
 
-set -e
-set -u
-set -o pipefail
+set -eu
+[ -n "${DEBUG:-}" ] && set -x
+
+usage() {
+  printf 'Usage: %s <SRC_DIR>\n' "$0" >&2
+  exit 64
+}
+
+rename_files() {
+  dir=$1
+  find "$dir" -maxdepth 1 -type f ! -name '.*' -print |
+    while IFS= read -r filepath; do
+      filename=$(basename "$filepath")
+      creation_date=$(stat -f "%SB" -t "%Y-%m-%dT%H_%M_%S%z" "$filepath" 2>/dev/null) || {
+        printf 'stat failed: %s\n' "$filepath" >&2
+        exit 3
+      }
+      new_filename="${creation_date}!~${filename}"
+      new_filepath="$dir/$new_filename"
+      if [ "$filepath" != "$new_filepath" ]; then
+        if [ -e "$new_filepath" ]; then
+          stem=$filename
+          ext=
+          case $filename in
+            *.*) stem=${filename%.*}; ext=.${filename##*.} ;;
+          esac
+          i=1
+          while [ -e "$dir/${creation_date}!~${stem}~$i$ext" ]; do
+            i=$((i + 1))
+          done
+          new_filename="${creation_date}!~${stem}~$i$ext"
+          new_filepath="$dir/$new_filename"
+        fi
+        if ! mv "$filepath" "$new_filepath"; then
+          printf 'Rename failed: %s\n' "$filepath" >&2
+          exit 3
+        fi
+      fi
+    done
+}
 
 main() {
-  emulate -L zsh
-  set -e
-  set -u
-  set -o pipefail
-
-  if (( $# != 1 )); then
-    print -u2 "Usage: $0 <SRC_DIR>"
-    return 64
-  fi
-
-  local SRC_DIR="$1"
-  [[ -d "$SRC_DIR" ]] || { print -u2 "Not a directory: $SRC_DIR"; return 2; }
-
-  # Only regular files; add D to include dotfiles: *(.ND)
-  setopt local_options null_glob
-
-  local filepath dir filename creation_date new_filename new_filepath
-  local i stem ext
-
-  for filepath in "$SRC_DIR"/*(.N); do
-    dir="${filepath:h}"
-    filename="${filepath:t}"
-
-    # macOS/BSD stat: %SB is birth time, -t sets strftime(3) format
-    # Example output: 2025-09-02T13_47_12-0700
-    creation_date=$(stat -f "%SB" -t "%Y-%m-%dT%H_%M_%S%z" "$filepath" 2>/dev/null) || {
-      print -u2 "stat failed: $filepath"
-      return 3
-    }
-
-    new_filename="${creation_date}!~${filename}"
-    new_filepath="$dir/$new_filename"
-
-    if [[ "$filepath" != "$new_filepath" ]]; then
-      # Avoid overwriting on collision by adding ~N before the extension
-      if [[ -e "$new_filepath" ]]; then
-        i=1
-        if [[ "$filename" == *.* && "$filename" != .* ]]; then
-          stem="${filename%.*}"; ext=".${filename##*.}"
-        else
-          stem="$filename"; ext=""
-        fi
-        while [[ -e "$dir/${creation_date}!~${stem}~$i$ext" ]]; do
-          (( i++ ))
-        done
-        new_filename="${creation_date}!~${stem}~$i$ext"
-        new_filepath="$dir/$new_filename"
-      fi
-
-      # BSD mv (no GNU --). Quoted paths are sufficient here.
-      mv "$filepath" "$new_filepath" || {
-        print -u2 "Rename failed: $filepath"
-        return 3
-      }
-    fi
-  done
+  [ "$#" -eq 1 ] || usage
+  SRC_DIR=$1
+  [ -d "$SRC_DIR" ] || {
+    printf 'Not a directory: %s\n' "$SRC_DIR" >&2
+    exit 2
+  }
+  rename_files "$SRC_DIR"
 }
 
 main "$@"

--- a/osx/install
+++ b/osx/install
@@ -19,9 +19,9 @@ uid_num=$(id -u)
 osxbin_dir="${script_dir}/bin"
 
 templates_dir="${script_dir}/templates"
-wrapper_template="${templates_dir}/wrapper.zsh"
-wrapper_release_template="${templates_dir}/wrapper-release.zsh"
-wrapper_releaseonly_template="${templates_dir}/wrapper-release-only.zsh"
+wrapper_template="${templates_dir}/wrapper.sh"
+wrapper_release_template="${templates_dir}/wrapper-release.sh"
+wrapper_releaseonly_template="${templates_dir}/wrapper-release-only.sh"
 
 machine=${MACHINE:-com.nashspence.scripts}
 podman_cpus=${PODMAN_CPUS:-14}

--- a/osx/templates/wrapper-release-only.sh
+++ b/osx/templates/wrapper-release-only.sh
@@ -1,5 +1,5 @@
-#!/bin/zsh
-set -euo pipefail
+#!/bin/sh
+set -eu
 # Auto-generated wrapper. Invokes 'podman-scripts-machine run' against a release.yaml only.
 export DR_WRAPPER_NAME="%NAME%"
 exec podman-scripts-machine run -r "%ABS%" "$@"

--- a/osx/templates/wrapper-release.sh
+++ b/osx/templates/wrapper-release.sh
@@ -1,5 +1,5 @@
-#!/bin/zsh
-set -euo pipefail
+#!/bin/sh
+set -eu
 # Auto-generated wrapper. Invokes 'podman-scripts-machine run' against a specific build file.
 export DR_WRAPPER_NAME="%NAME%"
-exec podman-scripts-machine run -f "%ABS%" "$@"
+exec podman-scripts-machine run -f "%ABS%" -r "%REL%" "$@"

--- a/osx/templates/wrapper.sh
+++ b/osx/templates/wrapper.sh
@@ -1,5 +1,5 @@
-#!/bin/zsh
-set -euo pipefail
+#!/bin/sh
+set -eu
 # Auto-generated wrapper. Invokes 'podman-scripts-machine run' against a specific build file.
 export DR_WRAPPER_NAME="%NAME%"
-exec podman-scripts-machine run -f "%ABS%" -r "%REL%" "$@"
+exec podman-scripts-machine run -f "%ABS%" "$@"


### PR DESCRIPTION
## Summary
- replace remaining zsh scripts with POSIX-compliant sh versions
- rename wrapper templates and update installer to use new sh files

## Testing
- `pre-commit run --files osx/bin/archive-record osx/bin/archive-videos osx/bin/birthrname osx/templates/wrapper.sh osx/templates/wrapper-release.sh osx/templates/wrapper-release-only.sh osx/install`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c56b50e308832b9a992b6aed548257