### PR TITLE
Allow positional ha-notify arguments for service and data

### DIFF
--- a/osx/bin/ha-notify
+++ b/osx/bin/ha-notify
@@ -1,30 +1,22 @@
 #!/bin/sh
 # Send a notification to Home Assistant via its REST API.
-# Usage: ha-notify.sh [-s service] [-d json-data] <title> <message>
+# Usage: ha-notify <service|*> <title> <message> [json-data]
 
 set -eu
 
-svc=notify
-data=
-
 usage() {
-    printf 'Usage: %s [-s service] [-d json-data] <title> <message>\n' "${0##*/}" >&2
+    printf 'Usage: %s <service|*> <title> <message> [json-data]\n' "${0##*/}" >&2
     exit 2
 }
 
-# Parse flags (POSIX getopts)
-while getopts 's:d:h' opt; do
-    case "$opt" in
-        s) svc=$OPTARG ;;
-        d) data=$OPTARG ;;
-        h|\?) usage ;;
-    esac
-done
-shift "$((OPTIND - 1))"
+svc=${1:-}
+title=${2:-}
+msg=${3:-}
+data=${4:-}
 
-title=${1:-}
-msg=${2:-}
-[ -n "$title" ] && [ -n "$msg" ] || usage
+[ -n "$svc" ] && [ -n "$title" ] && [ -n "$msg" ] || usage
+
+[ "$svc" = "*" ] && svc=notify
 
 # Minimal JSON string escaper (quotes + backslashes only)
 esc() {

--- a/osx/spec.md
+++ b/osx/spec.md
@@ -95,3 +95,18 @@
 * When I run kc with "delete"
 * And I pass the same name
 * Then the password is removed
+
+## Scenario: send a notification to all services
+* When I run ha-notify
+* And I pass "*"
+* And I pass a title
+* And I pass a message
+* Then Home Assistant receives the notification
+
+## Scenario: send a notification to a service with data
+* When I run ha-notify
+* And I pass "mobile_app_phone"
+* And I pass a title
+* And I pass a message
+* And I pass "\\{\\\"foo\\\":\\\"bar\\\"\\}"
+* Then Home Assistant receives the notification


### PR DESCRIPTION
## Summary
- support calling `ha-notify` with service, title, message, and optional JSON payload as positional args
- document new `ha-notify` usage scenarios

## Testing
- `pre-commit run --files osx/bin/ha-notify osx/spec.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c577598f58832b9d60f0e082e84aa0