### PR TITLE
Ensure use-scripts-machine waits for Podman

### DIFF
--- a/osx/bin/nsimg
+++ b/osx/bin/nsimg
@@ -22,8 +22,7 @@ MACHINE=${DR_MACHINE:-${MACHINE:-com.nashspence.scripts}}
 IMAGE_PREFIX=${DR_IMAGE_PREFIX:-com.nashspence.scripts.}
 TAG=${DR_TAG:-latest}
 
-use-scripts-machine "$$" &
-podman --connection "$MACHINE" info >/dev/null 2>&1 || true
+use-scripts-machine "$$"
 
 release_file="${dir}/release.yaml"
 containerfile=""

--- a/osx/bin/use-scripts-machine
+++ b/osx/bin/use-scripts-machine
@@ -16,27 +16,32 @@ case "$pid" in
 esac
 
 command -v nc >/dev/null 2>&1 || { echo "nc not found" >&2; exit 127; }
+command -v podman >/dev/null 2>&1 || { echo "podman not found" >&2; exit 127; }
 
 uid=$(id -u)
 sock="${DR_PODMAN_SOCK:-${PODMAN_SOCK:-/tmp/com.nashspence.scripts.podman-machine.${uid}.sock}}"
 
-nc -U "$sock" </dev/null >/dev/null &
-sock_pid=$!
+while kill -0 "$pid" 2>/dev/null; do
+    if podman --url "unix://$sock" info >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1 || exit 1
+done
+kill -0 "$pid" 2>/dev/null || exit 1
 
-cleanup() {
+(
+    nc -U "$sock" </dev/null >/dev/null &
+    sock_pid=$!
+    sleep 0.1
+    if ! kill -0 "$sock_pid" 2>/dev/null; then
+        wait "$sock_pid" 2>/dev/null || true
+        exit 1
+    fi
+    while kill -0 "$pid" 2>/dev/null; do
+        sleep 15 || break
+    done
     kill "$sock_pid" 2>/dev/null || true
     wait "$sock_pid" 2>/dev/null || true
-}
-trap cleanup EXIT INT HUP TERM
+) &
 
-# ensure connection succeeded
-sleep 0.1
-if ! kill -0 "$sock_pid" 2>/dev/null; then
-    wait "$sock_pid" 2>/dev/null || true
-    echo "failed to connect to $sock" >&2
-    exit 1
-fi
-
-while kill -0 "$pid" 2>/dev/null; do
-    sleep 15 || break
-done
+exit 0

--- a/osx/templates/wrapper-release-only.sh
+++ b/osx/templates/wrapper-release-only.sh
@@ -2,6 +2,6 @@
 set -eu
 # Auto-generated wrapper. Runs a portable container image.
 export DR_WRAPPER_NAME="%NAME%"
-use-scripts-machine "$$" &
+use-scripts-machine "$$"
 img=$(nsimg "%NAME%")
 exec podman run --rm "$img" "$@"

--- a/osx/templates/wrapper-release.sh
+++ b/osx/templates/wrapper-release.sh
@@ -2,6 +2,6 @@
 set -eu
 # Auto-generated wrapper. Runs a portable container image.
 export DR_WRAPPER_NAME="%NAME%"
-use-scripts-machine "$$" &
+use-scripts-machine "$$"
 img=$(nsimg "%NAME%")
 exec podman run --rm "$img" "$@"

--- a/osx/templates/wrapper.sh
+++ b/osx/templates/wrapper.sh
@@ -2,6 +2,6 @@
 set -eu
 # Auto-generated wrapper. Runs a portable container image.
 export DR_WRAPPER_NAME="%NAME%"
-use-scripts-machine "$$" &
+use-scripts-machine "$$"
 img=$(nsimg "%NAME%")
 exec podman run --rm "$img" "$@"


### PR DESCRIPTION
## Summary
- Have use-scripts-machine poll until the Podman machine is ready, then spawn a background socket holder for the given PID
- Run use-scripts-machine in foreground from wrappers and nsimg

## Testing
- `pre-commit run --files osx/bin/use-scripts-machine osx/bin/nsimg osx/templates/wrapper.sh osx/templates/wrapper-release.sh osx/templates/wrapper-release-only.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c581581f50832b909d751600926061