### PR TITLE
Handle podman-machine readiness via socket

### DIFF
--- a/osx/bin/use-scripts-machine
+++ b/osx/bin/use-scripts-machine
@@ -16,27 +16,29 @@ case "$pid" in
 esac
 
 command -v nc >/dev/null 2>&1 || { echo "nc not found" >&2; exit 127; }
-command -v podman >/dev/null 2>&1 || { echo "podman not found" >&2; exit 127; }
 
 uid=$(id -u)
 sock="${DR_PODMAN_SOCK:-${PODMAN_SOCK:-/tmp/com.nashspence.scripts.podman-machine.${uid}.sock}}"
 
-while kill -0 "$pid" 2>/dev/null; do
-    if podman --url "unix://$sock" info >/dev/null 2>&1; then
-        break
-    fi
-    sleep 1 || exit 1
-done
-kill -0 "$pid" 2>/dev/null || exit 1
+fifo=$(mktemp "${TMPDIR:-/tmp}/use-scripts-machine.XXXXXX")
+rm -f "$fifo"
+mkfifo "$fifo"
+
+nc -U "$sock" >"$fifo" &
+sock_pid=$!
+if ! IFS= read -r _ <"$fifo"; then
+    rm -f "$fifo"
+    wait "$sock_pid" 2>/dev/null || true
+    exit 1
+fi
+rm -f "$fifo"
+
+if ! kill -0 "$sock_pid" 2>/dev/null; then
+    wait "$sock_pid" 2>/dev/null || true
+    exit 1
+fi
 
 (
-    nc -U "$sock" </dev/null >/dev/null &
-    sock_pid=$!
-    sleep 0.1
-    if ! kill -0 "$sock_pid" 2>/dev/null; then
-        wait "$sock_pid" 2>/dev/null || true
-        exit 1
-    fi
     while kill -0 "$pid" 2>/dev/null; do
         sleep 15 || break
     done

--- a/osx/launch-agents/podman-machine/Scripts - Podman Machine
+++ b/osx/launch-agents/podman-machine/Scripts - Podman Machine
@@ -78,7 +78,8 @@ log "connection accepted; ensuring machine '$MACHINE' is running"
 podman machine start "$MACHINE" >/dev/null 2>&1 || true
 wait_podman_ready || true
 
-# Block until client closes (connected socket on stdin)
+# Notify the client that the machine is ready, then block until it disconnects
+printf 'ready\n'
 cat >/dev/null || true
 
 # Client disconnected — debounce, then quiesce-watch for a short window


### PR DESCRIPTION
## Summary
- have podman-machine launch agent send a ready notification once the VM is up
- wait for the ready message in `use-scripts-machine` instead of polling

## Testing
- `pre-commit run --files osx/bin/use-scripts-machine 'osx/launch-agents/podman-machine/Scripts - Podman Machine'`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c583c68f30832b96d5cd5de1ee314d