### PR TITLE
feat: output machine name from use-scripts-machine

### DIFF
--- a/osx/bin/nsimg
+++ b/osx/bin/nsimg
@@ -18,11 +18,9 @@ repo_dir=${PODMAN_SCRIPTS_DIR:-}
 dir="${repo_dir}/portable/${name}"
 [ -d "$dir" ] || { echo "portable directory not found: $name" >&2; exit 1; }
 
-MACHINE=${DR_MACHINE:-${MACHINE:-com.nashspence.scripts}}
+MACHINE=$(use-scripts-machine "$$")
 IMAGE_PREFIX=${DR_IMAGE_PREFIX:-com.nashspence.scripts.}
 TAG=${DR_TAG:-latest}
-
-use-scripts-machine "$$"
 
 release_file="${dir}/release.yaml"
 containerfile=""

--- a/osx/bin/use-scripts-machine
+++ b/osx/bin/use-scripts-machine
@@ -18,7 +18,8 @@ esac
 command -v nc >/dev/null 2>&1 || { echo "nc not found" >&2; exit 127; }
 
 uid=$(id -u)
-sock="${DR_PODMAN_SOCK:-${PODMAN_SOCK:-/tmp/com.nashspence.scripts.podman-machine.${uid}.sock}}"
+machine="${DR_MACHINE:-${MACHINE:-com.nashspence.scripts}}"
+sock="${DR_PODMAN_SOCK:-${PODMAN_SOCK:-/tmp/${machine}.podman-machine.${uid}.sock}}"
 
 fifo=$(mktemp "${TMPDIR:-/tmp}/use-scripts-machine.XXXXXX")
 rm -f "$fifo"
@@ -45,5 +46,5 @@ fi
     kill "$sock_pid" 2>/dev/null || true
     wait "$sock_pid" 2>/dev/null || true
 ) &
-
+printf '%s\n' "$machine"
 exit 0

--- a/osx/spec.md
+++ b/osx/spec.md
@@ -53,6 +53,8 @@
 * Given an image reference from nsimg
 * When I start use-scripts-machine for the current process
 * And I run podman
+* And I pass "--connection"
+* And I pass the machine name
 * And I pass "run"
 * And I pass "--rm"
 * And I pass the image reference
@@ -62,6 +64,8 @@
 ## Scenario: run another Podman subcommand
 * When I start use-scripts-machine for the current process
 * And I run podman
+* And I pass "--connection"
+* And I pass the machine name
 * And I pass "secret"
 * And I pass "ls"
 * Then Podman lists secrets from the machine


### PR DESCRIPTION
## Summary
- have use-scripts-machine print the Podman machine name and derive socket from it
- update nsimg to rely on use-scripts-machine's output
- document using the machine name with Podman connection

## Testing
- `pre-commit run --files osx/bin/nsimg`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c58aa467e0832bba8c4ad614173cc3