### PR TITLE
feat: avoid starting Podman machine on macOS install

### DIFF
--- a/osx/install
+++ b/osx/install
@@ -100,7 +100,7 @@ ensure_podman_machine() {
         --memory "${podman_mem}" \
         --disk-size "${podman_disk}" \
         "${machine}"
-    podman machine start "${machine}"
+    # do not start the machine; the launch agent or user will handle it
 }
 
 remove_podman_machine() {

--- a/osx/spec.md
+++ b/osx/spec.md
@@ -8,6 +8,7 @@
 * And the tools directory is added to the shell PATH
 * And the Podman Machine launch agent is loaded
 * And the On Mount launch agent is loaded
+* And the com.nashspence.scripts Podman machine is not running
 
 ## Scenario: uninstall the Podman machine environment
 * Given install has been run


### PR DESCRIPTION
## Summary
- stop auto-starting the Podman VM in the macOS install script
- document that the machine should remain stopped after installation

## Testing
- `pre-commit run --files osx/install osx/spec.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5a62149c4832bae23f4dc4b753b8f