### PR TITLE
Handle unreadable on-mount markers

### DIFF
--- a/osx/launch-agents/on-mount/Scripts - On Mount
+++ b/osx/launch-agents/on-mount/Scripts - On Mount
@@ -53,9 +53,10 @@ for vol in /Volumes/*; do
 
     prev_fsid=$(awk -F'\t' -v u="$uuid" '$1==u{print $2}' "$state")
     if [ "$fsid" != "$prev_fsid" ]; then
-        name=$(head -n 1 "$file" | tr -d '\r\n')
-        prog="$onmount_dir/$(basename "$name")"
         volname=$(basename "$vol")
+        name=$(head -n 1 "$file" 2>/dev/null | tr -d '\r\n' || true)
+        [ -n "$name" ] || continue
+        prog="$onmount_dir/$(basename "$name")"
         if [ -x "$prog" ]; then
             log "Executing \"$prog\" for \"$volname\""
             if ! osascript <<EOF


### PR DESCRIPTION
## Summary
- Skip on-mount volumes without readable marker files without logging a warning

## Testing
- `pre-commit run --files "osx/launch-agents/on-mount/Scripts - On Mount"`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5a60cb114832ba048633585c72312