### PR TITLE
Fix On Mount script exec invocation

### DIFF
--- a/osx/launch-agents/on-mount/Scripts - On Mount
+++ b/osx/launch-agents/on-mount/Scripts - On Mount
@@ -59,14 +59,16 @@ for vol in /Volumes/*; do
         prog="$onmount_dir/$(basename "$name")"
         if [ -x "$prog" ]; then
             log "Executing \"$prog\" for \"$volname\""
-            if ! osascript <<EOF
-tell application "Terminal"
-  set t to (do script "exec \\\"$prog\\\" \\\"$vol\\\"")
-  activate
-  try
-    set selected tab of (front window) to t
-  end try
-end tell
+            if ! osascript - "$prog" "$vol" <<'EOF'
+on run argv
+  tell application "Terminal"
+    set t to (do script ("exec " & quoted form of item 1 of argv & " " & quoted form of item 2 of argv))
+    activate
+    try
+      set selected tab of (front window) to t
+    end try
+  end tell
+end run
 EOF
             then
                 warn "osascript exited with status $? for \"$volname\""


### PR DESCRIPTION
## Summary
- ensure Scripts - On Mount correctly launches target executables by safely quoting program and volume paths

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5ad720438832bb707d8edcb52d2db