### PR TITLE
Clean up launch agent data during uninstall

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,6 +74,6 @@ repos:
               temp_manifest=manifest.json
             fi
             trap "test -n \"$temp_manifest\" && rm -f \"$temp_manifest\"" EXIT
-            exec "$BIN" format "$@"
+            exec env GAUGE_TELEMETRY_ENABLED=false "$BIN" format "$@" < <(printf "y\n")
           ' --
         files: (^|/)spec\.md$

--- a/osx/install
+++ b/osx/install
@@ -143,11 +143,7 @@ uninstall_launch_agent() {
     launchctl bootout "gui/${uid_num}" "${plist}" >/dev/null 2>&1 || true
     rm -f "${plist}"
 
-    case "$label" in
-        com.nashspence.scripts.podman-machine)
-            rm -rf "$dir/data" 2>/dev/null || true
-            ;;
-    esac
+    rm -rf "${dir}/data" 2>/dev/null || true
 }
 
 install_launch_agents() {


### PR DESCRIPTION
## Summary
- ensure uninstall script removes data directory for each launch agent
- run gauge format in pre-commit without requiring user input

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5b32cf598832b9ef0e28eac9c7d04