### PR TITLE
Revert pass-based secrets in macOS scripts

### DIFF
--- a/osx/bin/kc
+++ b/osx/bin/kc
@@ -14,20 +14,20 @@ warn() {
   printf '%s\n' "$*" >&2
 }
 
-pass_git_pull() {
-  if ! pass git pull --rebase >/dev/null 2>&1; then
-    warn 'warning: pass git pull failed; run "pass git pull --rebase"'
-  fi
-}
-
-pass_git_push() {
-  if ! pass git push >/dev/null 2>&1; then
-    warn 'warning: pass git push failed; run "pass git push"'
+read_secret() {
+  if [ "$force_stdin" -eq 1 ] || ! [ -t 0 ]; then
+    secret=$(cat)
+  else
+    printf 'Password: ' >&2
+    stty -echo
+    IFS= read -r secret
+    stty echo
+    printf '\n' >&2
   fi
 }
 
 cmd=${1:-}
-[ -n "${cmd:-}" ] || usage
+[ -n "$cmd" ] || usage
 
 force_stdin=0
 case "$cmd" in
@@ -56,44 +56,21 @@ case "$cmd" in
   *) usage ;;
 esac
 
-: "${PASSWORD_STORE_DIR:=$HOME/git/secrets}"
-export PASSWORD_STORE_DIR
-
 service="kc/${name}"
-
 : "${TMPDIR:=/tmp}"
 
 case "$cmd" in
-  add)
-    pass_git_pull
-    if [ "$force_stdin" -eq 1 ] || ! [ -t 0 ]; then
-      pass insert -m "$service" >/dev/null
-    else
-      pass insert "$service" >/dev/null
-    fi
-    pass_git_push
+  add|update)
+    read_secret
+    security add-generic-password -a "$name" -s "$service" -w "$secret" -U >/dev/null
     ;;
-
-  update)
-    pass_git_pull
-    if [ "$force_stdin" -eq 1 ] || ! [ -t 0 ]; then
-      pass insert -fm "$service" >/dev/null
-    else
-      pass insert -f "$service" >/dev/null
-    fi
-    pass_git_push
-    ;;
-
   get)
-    pass_git_pull
-    pass show "$service" | head -n1
+    security find-generic-password -a "$name" -s "$service" -w
     ;;
-
   get-secret)
-    pass_git_pull
     tmp="$(mktemp "${TMPDIR%/}/XXXXXXXX")"
     chmod 600 "$tmp"
-    if ! pass show "$service" >"$tmp"; then
+    if ! security find-generic-password -a "$name" -s "$service" -w >"$tmp"; then
       rm -f "$tmp"; exit 1
     fi
     MON_PID=$pid MON_FILE=$tmp nohup sh -c '
@@ -107,10 +84,7 @@ case "$cmd" in
     ' >/dev/null 2>&1 &
     printf '%s\n' "$tmp"
     ;;
-
   delete)
-    pass_git_pull
-    pass rm -f "$service" >/dev/null 2>&1 || true
-    pass_git_push
+    security delete-generic-password -a "$name" -s "$service" >/dev/null 2>&1 || true
     ;;
 esac

--- a/osx/install
+++ b/osx/install
@@ -1,7 +1,7 @@
 #!/bin/sh
-# install: install / uninstall activation + tooling + brew/podman/machine/pass
+# install: install / uninstall activation + tooling + brew/podman/machine
 # Usage:
-#   ./install [remote]        # Install activation + PATH + brew/podman/machine/pass
+#   ./install                 # Install activation + PATH + brew/podman/machine
 #   ./install --uninstall     # Remove EVERYTHING this script installed (incl. Podman machine)
 
 set -eu
@@ -21,14 +21,11 @@ podman_cpus=${PODMAN_CPUS:-14}
 podman_mem=${PODMAN_MEM:-20480}
 podman_disk=${PODMAN_DISK:-40}
 
-pass_repo=${PASS_REPO:-"${HOME}/git/secrets"}
-
 path_begin="# >>> podman-scripts PATH >>>"
 path_end="# <<< podman-scripts PATH <<<"
 export_repo_line="export PODMAN_SCRIPTS_DIR=\"${repo_dir}\""
 source_repo_line=". \"\${PODMAN_SCRIPTS_DIR}/lib.sh\""
 source_osx_line=". \"\${PODMAN_SCRIPTS_DIR}/osx/lib.sh\""
-password_store_line="export PASSWORD_STORE_DIR=\"${pass_repo}\""
 
 die() {
     printf 'ERROR: %s\n' "$*" >&2
@@ -44,7 +41,6 @@ add_path_block() {
             printf '%s\n' "${export_repo_line}"
             printf '%s\n' "${source_repo_line}"
             printf '%s\n' "${source_osx_line}"
-            printf '%s\n' "${password_store_line}"
             printf '%s\n' "${path_end}"
         } >>"${file}"
         printf '  + added PATH block to %s\n' "${file#"${HOME}/"}"
@@ -113,46 +109,6 @@ ensure_swiftc() {
     if command -v swiftc >/dev/null 2>&1; then return 0; fi
     if command -v xcrun >/dev/null 2>&1 && xcrun -f swiftc >/dev/null 2>&1; then return 0; fi
     die "swiftc not found. Install Xcode Command Line Tools (xcode-select --install) and re-run."
-}
-
-ensure_pass() {
-    if command -v pass >/dev/null 2>&1; then
-        return 0
-    fi
-    echo "Installing pass with Homebrew…"
-    brew list pass >/dev/null 2>&1 || brew install pass
-    command -v pass >/dev/null 2>&1 || die "pass not found after installation"
-}
-
-setup_pass_repo() {
-    remote=${1:-}
-    store="${pass_repo}"
-    mkdir -p "$store"
-    PASSWORD_STORE_DIR="$store"
-    export PASSWORD_STORE_DIR
-    if [ -d "$store/.git" ] && [ -f "$store/.gpg-id" ] && [ -z "$remote" ]; then
-        return 0
-    fi
-    if [ ! -d "$store/.git" ]; then
-        pass git init >/dev/null 2>&1 || true
-    fi
-    if [ ! -f "$store/.gpg-id" ]; then
-        gpg_id=$(gpg --list-secret-keys --with-colons 2>/dev/null | awk -F: '/^sec/ {print $5; exit}')
-        if [ -n "$gpg_id" ]; then
-            pass init "$gpg_id" >/dev/null 2>&1 || true
-        else
-            printf 'Warning: no GPG key found; run "gpg --gen-key" and re-run pass init\n' >&2
-        fi
-    fi
-    if [ -n "$remote" ]; then
-        if pass git remote get-url origin >/dev/null 2>&1; then
-            pass git remote set-url origin "$remote"
-        else
-            pass git remote add origin "$remote"
-        fi
-        pass git pull --rebase origin main >/dev/null 2>&1 || pass git pull --rebase origin master >/dev/null 2>&1 || true
-        pass git push -u origin HEAD >/dev/null 2>&1 || true
-    fi
 }
 
 remove_podman_machine() {
@@ -232,7 +188,6 @@ uninstall_launch_agents() {
 
 
 install_all() {
-    pass_remote=${1:-}
     [ -d "${bin_dir}" ] || die "required directory missing: ${bin_dir} (must contain 'use-scripts-machine' and 'nsimg')"
     [ -f "${bin_dir}/use-scripts-machine" ] || die "required tool missing: ${bin_dir}/use-scripts-machine"
     [ -f "${bin_dir}/nsimg" ] || die "required tool missing: ${bin_dir}/nsimg"
@@ -255,11 +210,9 @@ install_all() {
     add_path_block "${HOME}/.zshrc"
 
     ensure_brew
-    ensure_pass
     ensure_podman
     ensure_podman_machine
     ensure_swiftc
-    setup_pass_repo "$pass_remote"
 
     install_launch_agents
 
@@ -284,12 +237,12 @@ uninstall_all() {
 
 if [ "$#" -eq 1 ] && [ "$1" = "--uninstall" ]; then
     uninstall_all
-elif [ "$#" -le 1 ]; then
-    install_all "${1:-}"
+elif [ "$#" -eq 0 ]; then
+    install_all
 else
     cat <<USAGE >&2
 Usage:
-  $0 [remote]        Install activation + add paths + brew/podman/machine/pass
+  $0                 Install activation + add paths + brew/podman/machine
   $0 --uninstall     Remove EVERYTHING this script installed (incl. Podman machine)
 USAGE
     exit 2

--- a/osx/spec.md
+++ b/osx/spec.md
@@ -4,18 +4,11 @@
 * When I run install
 * Then Homebrew is installed
 * And Podman is installed
-* And pass is installed
-* And the secrets repository exists
 * And the com.nashspence.scripts Podman machine exists
 * And the bin directories are added to the shell PATH
 * And the Podman Machine launch agent is loaded
 * And the On Mount launch agent is loaded
 * And the com.nashspence.scripts Podman machine is not running
-
-## Scenario: initialise pass from a remote
-* When I run install
-* And I pass a remote URL
-* Then the secrets repository is synced from that remote
 
 ## Scenario: uninstall the Podman machine environment
 * Given install has been run


### PR DESCRIPTION
## Summary
- drop pass integration from macOS install script and keychain helper
- restore kc to use `security` keychain commands
- update macOS spec to remove pass references

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7bd2f2c6c832b9c28d2e6f00d0127