### PR TITLE
Expose SVT-AV1 lp parameter for qcut and vcrunch

### DIFF
--- a/containers/qcut/script.py
+++ b/containers/qcut/script.py
@@ -356,6 +356,12 @@ def main() -> None:
     )
     ap.add_argument("--svt-preset", type=int, default=int(os.getenv("SVT_PRESET", "5")))
     ap.add_argument("--svt-crf", type=int, default=int(os.getenv("SVT_CRF", "32")))
+    ap.add_argument(
+        "--svt-lp",
+        type=int,
+        default=int(os.getenv("SVT_LP", "5")),
+        help="Number of SVT-AV1 lookahead processes (lp parameter).",
+    )
     ap.add_argument("--opus-br", default=os.getenv("OPUS_BR", "128k"))
     # IMPORTANT: tp has no default; if omitted -> no limiter
     ap.add_argument(
@@ -468,6 +474,7 @@ def main() -> None:
             "max_sec": args.max,
             "svt_preset": args.svt_preset,
             "svt_crf": args.svt_crf,
+            "svt_lp": args.svt_lp,
             "opus_br": args.opus_br,
             "tp": args.tp,  # None -> no limiter
             "fontfile": args.fontfile,
@@ -534,6 +541,10 @@ def main() -> None:
         )
     else:
         log(f"Plan loaded: {len(m['clips'])} clips")
+
+    if m.get("plan") and "svt_lp" not in m["plan"]:
+        m["plan"]["svt_lp"] = args.svt_lp
+        save_manifest(args.autoedit_dir, m)
 
     # 2) Encode pending clips
     done = sum(
@@ -610,7 +621,7 @@ def main() -> None:
                 "-crf",
                 str(m["plan"]["svt_crf"]),
                 "-svtav1-params",
-                "lp=5",
+                f"lp={m['plan']['svt_lp']}",
                 "-c:a",
                 "libopus",
                 "-b:a",

--- a/containers/qcut/spec.md
+++ b/containers/qcut/spec.md
@@ -5,9 +5,11 @@
 * And an output directory "<out>"
 * When I pass --src-dir "<src>"
 * And I pass --autoedit-dir "<out>"
+* And I pass --svt-lp "<lp>"
 * And I run qcut
 * Then qcut writes the final video to "<out>"
 * And the final video shows timestamp overlays
+* And the encode uses SVT-AV1 lp "<lp>"
 
 ## Scenario: enable verbose logging
 * Given a directory "<src>" containing videos

--- a/containers/vcrunch/script.py
+++ b/containers/vcrunch/script.py
@@ -301,6 +301,12 @@ def main() -> None:
         help="Local work dir inside the container; inputs are staged here before encoding.",
     )
     ap.add_argument(
+        "--svt-lp",
+        type=int,
+        default=int(os.getenv("SVT_LP", "5")),
+        help="Number of SVT-AV1 lookahead processes (lp parameter).",
+    )
+    ap.add_argument(
         "-v",
         "--verbose",
         action="count",
@@ -558,7 +564,7 @@ def main() -> None:
             "-preset",
             "5",
             "-svtav1-params",
-            "lp=5",
+            f"lp={args.svt_lp}",
             "-c:a",
             "libopus",
             "-b:a",

--- a/containers/vcrunch/spec.md
+++ b/containers/vcrunch/spec.md
@@ -10,6 +10,7 @@
 * And I pass --output-dir "<out>"
 * And I pass --manifest-name "<manifest>"
 * And I pass --name-suffix "<suffix>"
+* And I pass --svt-lp "<lp>"
 * And I run vcrunch
 * Then vcrunch creates an AV1 file in "<out>"
 * And the file name ends with "<suffix>.mkv"
@@ -17,6 +18,7 @@
 * And the encode respects the target size
 * And the encode respects the audio bitrate
 * And the encode respects the safety overhead
+* And the encode uses the SVT-AV1 lp "<lp>"
 
 ## Scenario: skip already encoded videos
 * Given an MP4 file "<src>"


### PR DESCRIPTION
## Summary
- add an --svt-lp option to qcut, persist it in the manifest, and apply it when invoking ffmpeg
- add an --svt-lp option to vcrunch that is forwarded to libsvtav1
- update the qcut and vcrunch specs to cover the new lookahead argument

## Testing
- pre-commit run --all-files
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cc73420d90832ba7a98e37779f14fb