### PR TITLE
Revert guess_date renaming workflow

### DIFF
--- a/containers/guess_date/spec.md
+++ b/containers/guess_date/spec.md
@@ -1,19 +1,13 @@
 # guess_date
 
-## Scenario: flatten files into timestamped names
-* Given a directory "input/photos"
-* And the file "input/photos/image.jpg" has modification time "2024-01-02T03:04:05"
-* And an empty directory "output"
-* When I set the command argument "input"
-* And I set the command argument "output"
+## Scenario: print the detected creation timestamp
+* Given a media file "<media>"
+* When I pass "<media>"
 * And I run guess_date
-* Then the directory "output" contains a file named "2024-01-02T03-04-05 photos__image.jpg"
+* Then guess_date prints the creation timestamp
 
-## Scenario: send undated files to the unknown directory
-* Given a directory "input"
-* And the file "input/clip.mov" has no detectable timestamp metadata
-* And an empty directory "output"
-* When I set the command argument "input"
-* And I set the command argument "output"
+## Scenario: prefer interactive selection when scores tie
+* Given multiple timestamps with similar confidence
+* When I pass "<media>"
 * And I run guess_date
-* Then the directory "output/unknown" contains a file named "clip.mov"
+* Then guess_date prompts me to choose a timestamp


### PR DESCRIPTION
## Summary
- restore guess_date to print the selected timestamp instead of copying or renaming files
- revert the spec to cover timestamp output and interactive selection behaviour
- restore the earlier unit tests that validate timestamp parsing and selection

## Testing
- pre-commit run --all-files
- pytest containers/guess_date/tests/test_guess_date.py

------
https://chatgpt.com/codex/tasks/task_e_68dd895970d0832bb43080bd4e2062d2