### PR TITLE
Add option to fail when only mtime is available

### DIFF
--- a/containers/guess_date/spec.md
+++ b/containers/guess_date/spec.md
@@ -11,3 +11,10 @@
 * When I pass "<media>"
 * And I run guess_date
 * Then guess_date prompts me to choose a timestamp
+
+## Scenario: fail when only filesystem mtime is available
+* Given a media file "<media>"
+* When I pass "<media>"
+* And I pass "--fail-on-mtime-only"
+* And I run guess_date
+* Then guess_date exits with status 1


### PR DESCRIPTION
## Summary
- add a --fail-on-mtime-only flag to guess_date and exit early when mtime is the lone timestamp
- document the new behaviour in the container specification
- add regression tests covering the new flag in both failure and success cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd9af47f1c832b91c8d81182c558c4