### PR TITLE
Fix vcrunch still image detection

### DIFF
--- a/containers/vcrunch/script.py
+++ b/containers/vcrunch/script.py
@@ -228,13 +228,15 @@ def _parse_frame_count(value: Any) -> Optional[float]:
 def probe_media_info(path: str) -> MediaProbeResult:
     cmd = [
         "ffprobe",
+        "-count_frames",
         "-hide_banner",
         "-loglevel",
         "error",
         "-show_entries",
         (
             "format=duration:format_tags=DURATION:stream="
-            "codec_type,duration,duration_ts,time_base,avg_frame_rate,nb_frames,r_frame_rate"
+            "codec_type,duration,duration_ts,time_base,avg_frame_rate,nb_frames,"
+            "nb_read_frames,r_frame_rate"
         ),
         "-of",
         "json",
@@ -263,6 +265,8 @@ def probe_media_info(path: str) -> MediaProbeResult:
                 continue
             has_video_stream = True
             frame_count = _parse_frame_count(stream.get("nb_frames"))
+            if frame_count is None:
+                frame_count = _parse_frame_count(stream.get("nb_read_frames"))
             stream_duration = _parse_duration_value(stream.get("duration"))
             if stream_duration is None:
                 stream_duration = _duration_from_timebase(

--- a/containers/vcrunch/tests/test_script.py
+++ b/containers/vcrunch/tests/test_script.py
@@ -62,13 +62,15 @@ def test_ffprobe_duration(monkeypatch):
 def test_probe_media_info_uses_format_duration(monkeypatch):
     expected = [
         "ffprobe",
+        "-count_frames",
         "-hide_banner",
         "-loglevel",
         "error",
         "-show_entries",
         (
             "format=duration:format_tags=DURATION:stream="
-            "codec_type,duration,duration_ts,time_base,avg_frame_rate,nb_frames,r_frame_rate"
+            "codec_type,duration,duration_ts,time_base,avg_frame_rate,nb_frames,"
+            "nb_read_frames,r_frame_rate"
         ),
         "-of",
         "json",
@@ -124,6 +126,26 @@ def test_probe_media_info_still_image(monkeypatch):
                     "r_frame_rate": "25/1",
                 }
             ],
+        }
+
+    monkeypatch.setattr(script, "ffprobe_json", fake_ffprobe_json)
+    info = script.probe_media_info("photo.jpg")
+    assert info["is_video"] is False
+    assert info["duration"] is None
+
+
+def test_probe_media_info_still_image_counts_frames(monkeypatch):
+    def fake_ffprobe_json(cmd):
+        return {
+            "streams": [
+                {
+                    "codec_type": "video",
+                    "duration": "0.04",
+                    "nb_frames": "N/A",
+                    "nb_read_frames": "1",
+                    "avg_frame_rate": "25/1",
+                }
+            ]
         }
 
     monkeypatch.setattr(script, "ffprobe_json", fake_ffprobe_json)


### PR DESCRIPTION
## Summary
- ensure vcrunch uses ffprobe frame counting output to avoid classifying single-frame inputs as videos
- extend unit tests to cover the nb_read_frames fallback path

## Testing
- pytest
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68df2e95637c832b9eb9f1cb10db08ad