### PR TITLE
Use MP4 output for MOV inputs with data streams

### DIFF
--- a/containers/vcrunch/script.py
+++ b/containers/vcrunch/script.py
@@ -911,7 +911,10 @@ def main() -> None:
         preserve_data_streams = False
         output_ext = OUT_EXT
         if has_data_streams and ext and _muxer_supports_av1(muxer_for_src):
-            output_ext = ext
+            if ext.lower() == ".mov":
+                output_ext = ".mp4"
+            else:
+                output_ext = ext
             preserve_data_streams = True
         out_name = f"{stem}{args.name_suffix}{output_ext}"
         metadata = {


### PR DESCRIPTION
## Summary
- ensure MOV sources that include data streams are re-muxed to MP4 outputs while preserving data tracks

## Testing
- pre-commit run --all-files
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dff494c3c4832b8f6659011271df37