### PR TITLE
Ensure mov data streams to mp4 keep unknown data

### DIFF
--- a/containers/vcrunch/script.py
+++ b/containers/vcrunch/script.py
@@ -975,6 +975,14 @@ def main() -> None:
             else:
                 output_ext = ext
             preserve_data_streams = True
+        should_copy_unknown = preserve_data_streams
+        if (
+            has_data_streams
+            and ext
+            and ext.lower() == ".mov"
+            and output_ext.lower() == ".mp4"
+        ):
+            should_copy_unknown = True
         out_name = f"{stem}{args.name_suffix}{output_ext}"
         metadata = {
             "dir": os.path.abspath(os.path.dirname(src)),
@@ -1087,7 +1095,7 @@ def main() -> None:
                 "warning",
             ]
         ff.append("-y")
-        if not preserve_data_streams:
+        if not preserve_data_streams and not should_copy_unknown:
             ff.append("-ignore_unknown")
         ff += [
             "-i",
@@ -1143,7 +1151,7 @@ def main() -> None:
                 "-c:d",
                 "copy",
             ]
-        if preserve_data_streams:
+        if should_copy_unknown:
             ff.append("-copy_unknown")
         if muxer == "matroska":
             ff += [


### PR DESCRIPTION
## Summary
- ensure MOV sources with data streams promoted to MP4 always request `-copy_unknown`
- skip `-ignore_unknown` when copying unknown streams to retain ancillary data

## Testing
- pre-commit run --all-files
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0029bcb44832b9a622a540d287894