### PR TITLE
Preserve mov container when copying data streams

### DIFF
--- a/containers/vcrunch/script.py
+++ b/containers/vcrunch/script.py
@@ -983,18 +983,10 @@ def main() -> None:
         preserve_data_streams = False
         output_ext = OUT_EXT
         if has_data_streams and ext and _muxer_supports_av1(muxer_for_src):
-            if ext.lower() == ".mov":
-                output_ext = ".mp4"
-            else:
-                output_ext = ext
+            output_ext = ext
             preserve_data_streams = True
         should_copy_unknown = preserve_data_streams
-        if (
-            has_data_streams
-            and ext
-            and ext.lower() == ".mov"
-            and output_ext.lower() == ".mp4"
-        ):
+        if has_data_streams and ext and ext.lower() == ".mov":
             should_copy_unknown = True
         out_name = f"{stem}{args.name_suffix}{output_ext}"
         metadata = {
@@ -1166,6 +1158,11 @@ def main() -> None:
             ]
         if should_copy_unknown:
             ff.append("-copy_unknown")
+        if preserve_data_streams and output_ext.lower() == ".mov":
+            ff += [
+                "-brand",
+                "isom",
+            ]
         if muxer == "matroska":
             ff += [
                 "-cues_to_front",


### PR DESCRIPTION
## Summary
- keep MOV inputs with data streams in a MOV container and add the required isom brand flag while continuing to copy unknown streams
- add coverage that asserts MOV outputs keep the container and request the correct ffmpeg flags

## Testing
- pre-commit run --all-files *(fails: gauge-format hook cannot launch cached gauge binary)*
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e009939b90832bbff2f8ce07d9af19