### PR TITLE
Remove mkvmerge dependencies from vcrunch

### DIFF
--- a/containers/vcrunch/Containerfile
+++ b/containers/vcrunch/Containerfile
@@ -11,7 +11,7 @@ LABEL org.opencontainers.image.source="${VCS_URL}" \
       org.opencontainers.image.revision="${VCS_REF}" \
       org.opencontainers.image.version="${VERSION}"
 
-RUN apk add --no-cache coreutils mkvtoolnix
+RUN apk add --no-cache coreutils
 COPY --from=ffmpeg /ffmpeg /usr/local/bin/ffmpeg
 COPY --from=ffmpeg /ffprobe /usr/local/bin/ffprobe
 WORKDIR /app

--- a/containers/vcrunch/tests/test_script.py
+++ b/containers/vcrunch/tests/test_script.py
@@ -571,7 +571,6 @@ def test_mov_with_data_stream_outputs_mkv(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(script, "ffprobe_duration", lambda path: 60.0)
     monkeypatch.setattr(script, "find_start_timecode", lambda path: "01:02:03:04")
-    monkeypatch.setattr(script, "write_timecodes_v2", lambda src, dest: False)
     monkeypatch.setattr(script.shutil, "which", lambda name: None)
 
     captured_cmds = []


### PR DESCRIPTION
## Summary
- stop installing mkvtoolnix in the vcrunch container image
- drop mkvmerge remux/timecode handling so we use ffmpeg output directly
- update the vcrunch unit test to reflect the simplified pipeline

## Testing
- pre-commit run --all-files *(fails: gauge-format: env: '/root/.cache/gauge/gauge': Text file busy)*
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e01a059b70832b86de8b0a4a5dc768