### PR TITLE
Install mkvmerge dependency in vcrunch container

### DIFF
--- a/containers/vcrunch/Containerfile
+++ b/containers/vcrunch/Containerfile
@@ -11,7 +11,7 @@ LABEL org.opencontainers.image.source="${VCS_URL}" \
       org.opencontainers.image.revision="${VCS_REF}" \
       org.opencontainers.image.version="${VERSION}"
 
-RUN apk add --no-cache coreutils
+RUN apk add --no-cache coreutils mkvtoolnix
 COPY --from=ffmpeg /ffmpeg /usr/local/bin/ffmpeg
 COPY --from=ffmpeg /ffprobe /usr/local/bin/ffprobe
 WORKDIR /app

--- a/containers/vcrunch/spec.md
+++ b/containers/vcrunch/spec.md
@@ -12,6 +12,7 @@
 * And I pass --name-suffix "<suffix>"
 * And I pass --svt-lp "<lp>"
 * And I run vcrunch
+* And vcrunch remuxes the encoded video with mkvmerge
 * Then vcrunch creates an AV1 file in "<out>"
 * And the file name ends with "<suffix>.mkv"
 * And "<manifest>" records "<src>" as done

--- a/containers/vcrunch/tests/test_script.py
+++ b/containers/vcrunch/tests/test_script.py
@@ -467,8 +467,13 @@ def test_constant_quality_groups_and_command(monkeypatch, tmp_path):
 
     def fake_run(cmd, env=None):
         captured_cmds.append(cmd)
-        stage_part = Path(cmd[-1])
-        stage_part.write_bytes(b"encoded")
+        if cmd[0] == "ffmpeg":
+            stage_part = Path(cmd[-1])
+            stage_part.write_bytes(b"encoded")
+        elif cmd[0] == "mkvmerge":
+            output_path = Path(cmd[2])
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(b"remuxed")
 
         class R:
             returncode = 0
@@ -537,9 +542,14 @@ def test_mov_with_data_stream_outputs_mkv(monkeypatch, tmp_path):
 
     def fake_run(cmd, env=None):
         captured_cmds.append(cmd)
-        output_path = Path(cmd[-1])
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_bytes(b"encoded")
+        if cmd[0] == "ffmpeg":
+            output_path = Path(cmd[-1])
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(b"encoded")
+        elif cmd[0] == "mkvmerge":
+            output_path = Path(cmd[2])
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(b"remuxed")
 
         class R:
             returncode = 0
@@ -612,8 +622,13 @@ def test_sidecar_files_are_renamed(monkeypatch, tmp_path):
     monkeypatch.setattr(script, "ffprobe_duration", lambda path: 60.0)
 
     def fake_run(cmd, env=None):
-        stage_part = Path(cmd[-1])
-        stage_part.write_bytes(b"encoded")
+        if cmd[0] == "ffmpeg":
+            stage_part = Path(cmd[-1])
+            stage_part.write_bytes(b"encoded")
+        elif cmd[0] == "mkvmerge":
+            output_path = Path(cmd[2])
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(b"remuxed")
 
         class R:
             returncode = 0


### PR DESCRIPTION
## Summary
- install the mkvtoolnix package in the vcrunch container image so mkvmerge is available for remuxing

## Testing
- pre-commit run --all-files (fails: gauge format hook cannot run in container because Gauge binary is busy)
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e17e879b98832b9f42ace3b01d345d