### PR TITLE
Mux metadata and attachments directly with mkvmerge

### DIFF
--- a/containers/vcrunch/Containerfile
+++ b/containers/vcrunch/Containerfile
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1.7
 ARG TARGETPLATFORM
-ARG VERSION
-ARG VCS_REF
-ARG VCS_URL
+ARG VERSION=dev
+ARG VCS_REF=unknown
+ARG VCS_URL=https://example.invalid
 
 FROM --platform=$TARGETPLATFORM mwader/static-ffmpeg:latest AS ffmpeg
 FROM --platform=$TARGETPLATFORM python:3.12-alpine
@@ -11,14 +11,16 @@ LABEL org.opencontainers.image.source="${VCS_URL}" \
       org.opencontainers.image.revision="${VCS_REF}" \
       org.opencontainers.image.version="${VERSION}"
 
-RUN apk add --no-cache coreutils curl tar xz \
-    && curl -fsSL https://mkvtoolnix.download/builds/alpine-linux/mkvtoolnix-64-bit-95.0-alpine-linux-musl.tar.xz -o /tmp/mkvtoolnix.tar.xz \
-    && mkdir -p /opt/mkvtoolnix \
-    && tar -xJf /tmp/mkvtoolnix.tar.xz -C /opt/mkvtoolnix --strip-components=1 \
-    && rm /tmp/mkvtoolnix.tar.xz \
-    && for bin in /opt/mkvtoolnix/bin/*; do ln -sf "$bin" /usr/local/bin/; done
+# Add edge/community repo only for mkvtoolnix 95.0, then install
+RUN set -eux; \
+    echo "https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories; \
+    apk add --no-cache coreutils curl tar xz mkvtoolnix; \
+    mkvmerge --version
+
+# Bring in static ffmpeg/ffprobe
 COPY --from=ffmpeg /ffmpeg /usr/local/bin/ffmpeg
 COPY --from=ffmpeg /ffprobe /usr/local/bin/ffprobe
+
 WORKDIR /app
 COPY script.py /app/vcrunch
 ENTRYPOINT ["python", "/app/vcrunch"]

--- a/containers/vcrunch/Containerfile
+++ b/containers/vcrunch/Containerfile
@@ -11,7 +11,12 @@ LABEL org.opencontainers.image.source="${VCS_URL}" \
       org.opencontainers.image.revision="${VCS_REF}" \
       org.opencontainers.image.version="${VERSION}"
 
-RUN apk add --no-cache coreutils mkvtoolnix
+RUN apk add --no-cache coreutils curl tar xz \
+    && curl -fsSL https://mkvtoolnix.download/builds/alpine-linux/mkvtoolnix-64-bit-95.0-alpine-linux-musl.tar.xz -o /tmp/mkvtoolnix.tar.xz \
+    && mkdir -p /opt/mkvtoolnix \
+    && tar -xJf /tmp/mkvtoolnix.tar.xz -C /opt/mkvtoolnix --strip-components=1 \
+    && rm /tmp/mkvtoolnix.tar.xz \
+    && for bin in /opt/mkvtoolnix/bin/*; do ln -sf "$bin" /usr/local/bin/; done
 COPY --from=ffmpeg /ffmpeg /usr/local/bin/ffmpeg
 COPY --from=ffmpeg /ffprobe /usr/local/bin/ffprobe
 WORKDIR /app

--- a/containers/vcrunch/script.py
+++ b/containers/vcrunch/script.py
@@ -3540,13 +3540,11 @@ def main() -> None:
 
             mux_cmd = [
                 "mkvmerge",
-                "-o",
-                remux_output,
                 "--disable-track-statistics-tags",
             ]
             mux_cmd += metadata_args
             mux_cmd += attachment_args
-            mux_cmd.append(str(selected_output_path))
+            mux_cmd += ["-o", remux_output, str(selected_output_path)]
             _print_command(mux_cmd)
             mux_proc = subprocess.run(mux_cmd)
             if mux_proc.returncode != 0:

--- a/containers/vcrunch/script.py
+++ b/containers/vcrunch/script.py
@@ -1251,7 +1251,7 @@ def _prepare_container_metadata_args(
         remaining_tags.append((key, stripped))
 
     if creation_date:
-        metadata_args.append(f"--date={creation_date}")
+        metadata_args += ["--date", creation_date]
     if title_value:
         metadata_args += ["--title", title_value]
 
@@ -3540,11 +3540,13 @@ def main() -> None:
 
             mux_cmd = [
                 "mkvmerge",
+                "-o",
+                remux_output,
                 "--disable-track-statistics-tags",
             ]
             mux_cmd += metadata_args
             mux_cmd += attachment_args
-            mux_cmd += ["-o", remux_output, str(selected_output_path)]
+            mux_cmd.append(str(selected_output_path))
             _print_command(mux_cmd)
             mux_proc = subprocess.run(mux_cmd)
             if mux_proc.returncode != 0:

--- a/containers/vcrunch/script.py
+++ b/containers/vcrunch/script.py
@@ -3540,11 +3540,13 @@ def main() -> None:
 
             mux_cmd = [
                 "mkvmerge",
+                "-o",
+                remux_output,
                 "--disable-track-statistics-tags",
             ]
             mux_cmd += metadata_args
             mux_cmd += attachment_args
-            mux_cmd += ["-o", remux_output, str(selected_output_path)]
+            mux_cmd.append(str(selected_output_path))
             _print_command(mux_cmd)
             mux_proc = subprocess.run(mux_cmd)
             if mux_proc.returncode != 0:

--- a/containers/vcrunch/script.py
+++ b/containers/vcrunch/script.py
@@ -1251,7 +1251,7 @@ def _prepare_container_metadata_args(
         remaining_tags.append((key, stripped))
 
     if creation_date:
-        metadata_args += ["--date", creation_date]
+        metadata_args.append(f"--date={creation_date}")
     if title_value:
         metadata_args += ["--title", title_value]
 
@@ -3540,13 +3540,11 @@ def main() -> None:
 
             mux_cmd = [
                 "mkvmerge",
-                "-o",
-                remux_output,
                 "--disable-track-statistics-tags",
             ]
             mux_cmd += metadata_args
             mux_cmd += attachment_args
-            mux_cmd.append(str(selected_output_path))
+            mux_cmd += ["-o", remux_output, str(selected_output_path)]
             _print_command(mux_cmd)
             mux_proc = subprocess.run(mux_cmd)
             if mux_proc.returncode != 0:

--- a/containers/vcrunch/script.py
+++ b/containers/vcrunch/script.py
@@ -764,10 +764,9 @@ def _dump_streams_and_metadata(
 
             logging.warning("failed to export stream %s: %s", index, exc)
 
-    attachments = _export_attachments(src, dest_dir, verbose)
     return {
         "exports": exports,
-        "attachments": attachments,
+        "attachments": [],
         "metadata_path": meta_path,
         "container_tags": container_tags,
         "stream_infos": stream_infos,
@@ -1224,31 +1223,46 @@ def _clean_attachment_description(text: str) -> str:
     return cleaned[:120]
 
 
-def _attach_sidecar_files(
-    mkv_path: str, attachments: Sequence[Tuple[pathlib.Path, str, str]]
-) -> None:
-    if not attachments:
-        return
+def _format_size_for_log(num_bytes: int) -> str:
+    return (
+        f"{num_bytes / float(1024**2):.2f} MiB ({num_bytes:,} bytes)"
+        if num_bytes >= 0
+        else f"{num_bytes:,} bytes"
+    )
+
+
+def _build_attachment_args(
+    attachments: Sequence[Tuple[pathlib.Path, str, str]]
+) -> List[str]:
+    args: List[str] = []
     for path, description, mime_type in attachments:
         if not path.exists():
             continue
         desc = _clean_attachment_description(description) or path.name
         name = path.name
-
-        cmd = ["mkvpropedit", mkv_path]
-        if name:
-            cmd.extend(["--attachment-name", name])
-        if mime_type:
-            cmd.extend(["--attachment-mime-type", mime_type])
-        if desc:
-            cmd.extend(["--attachment-description", desc])
-        cmd.extend(["--add-attachment", str(path)])
-        _print_command(cmd)
-        proc = subprocess.run(cmd)
-        if proc.returncode != 0:
-            raise RuntimeError(
-                f"mkvpropedit failed to attach {path} with code {proc.returncode}"
+        label = name or desc or str(path)
+        try:
+            size = path.stat().st_size
+        except OSError as exc:
+            logging.info(
+                "including attachment %s: size unavailable (%s)",
+                label,
+                exc,
             )
+        else:
+            logging.info(
+                "including attachment %s: %s",
+                label,
+                _format_size_for_log(size),
+            )
+        if name:
+            args.extend(["--attachment-name", name])
+        if mime_type:
+            args.extend(["--attachment-mime-type", mime_type])
+        if desc:
+            args.extend(["--attachment-description", desc])
+        args.extend(["--attach-file", str(path)])
+    return args
 
 
 def _apply_birthtime(path: str, birthtime: float) -> None:
@@ -1318,13 +1332,13 @@ def _build_container_tags_xml(entries: List[Tuple[str, str]]) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _apply_container_metadata(
-    mkv_path: str,
+def _prepare_container_metadata_args(
+    output_path: str,
     creation_date: Optional[str],
     tags: Dict[str, str],
     cleanup: List[str],
-) -> None:
-    info_updates: List[Tuple[str, str]] = []
+) -> List[str]:
+    metadata_args: List[str] = []
     remaining_tags: List[Tuple[str, str]] = []
 
     title_value = None
@@ -1343,34 +1357,21 @@ def _apply_container_metadata(
         remaining_tags.append((key, stripped))
 
     if creation_date:
-        info_updates.append(("date", creation_date))
+        metadata_args += ["--date", creation_date]
     if title_value:
-        info_updates.append(("title", title_value))
+        metadata_args += ["--title", title_value]
 
-    tags_file: Optional[pathlib.Path] = None
     if remaining_tags:
         xml_text = _build_container_tags_xml(remaining_tags)
-        tags_file = pathlib.Path(mkv_path + ".container.tags.xml")
+        tags_file = pathlib.Path(f"{output_path}.container.tags.xml")
         try:
             tags_file.write_text(xml_text, encoding="utf-8")
         except OSError as exc:
             raise RuntimeError(f"failed to write container tags XML: {exc}") from exc
         cleanup.append(str(tags_file))
+        metadata_args += ["--global-tags", str(tags_file)]
 
-    if not info_updates and tags_file is None:
-        return
-
-    cmd: List[str] = ["mkvpropedit", mkv_path]
-    if info_updates:
-        cmd += ["--edit", "info"]
-        for key, value in info_updates:
-            cmd += ["--set", f"{key}={value}"]
-    if tags_file is not None:
-        cmd += ["--tags", f"global:{tags_file}"]
-    _print_command(cmd)
-    proc = subprocess.run(cmd)
-    if proc.returncode != 0:
-        raise RuntimeError(f"mkvpropedit exited with code {proc.returncode}")
+    return metadata_args
 
 
 class MediaPreset(TypedDict):
@@ -2313,6 +2314,7 @@ def main() -> None:
     video_copy_specs: Dict[str, set[str]] = {}
     total_audio_bytes = 0
     other_stream_bytes = 0
+    attachment_budget_bytes = 0
     audio_budget_debug: List[BudgetDebugEntry] = []
     other_stream_budget_debug: List[BudgetDebugEntry] = []
     video_entries: List[Dict[str, Any]] = []
@@ -2478,6 +2480,7 @@ def main() -> None:
                             debug_source=os.path.basename(src),
                         )
                         other_stream_bytes += estimated
+                        attachment_budget_bytes += estimated
                         if debug_entry is not None:
                             record_entry = debug_entry
                         else:
@@ -2568,6 +2571,8 @@ def main() -> None:
                         debug_source=os.path.basename(src),
                     )
                     other_stream_bytes += estimated
+                    if stype == "t":
+                        attachment_budget_bytes += estimated
                     if debug_entry is not None:
                         record_entry = debug_entry
                     else:
@@ -3073,6 +3078,7 @@ def main() -> None:
 
     logging.info("target bytes: %s", f"{target_bytes:,}")
     logging.info("asset bytes: %s", f"{asset_bytes:,}")
+    logging.info("attachment budget bytes: %s", f"{attachment_budget_bytes:,}")
     if not use_constant_quality:
         logging.info(
             "stream overhead bytes: %s; copied video bytes: %s",
@@ -3221,7 +3227,6 @@ def main() -> None:
                 mark_pending("failed to dump streams")
                 continue
             exports = dumped["exports"]
-            attachments = dumped["attachments"]
             metadata_sidecar = dumped["metadata_path"]
             container_tags = dumped.get("container_tags", {})
 
@@ -3584,15 +3589,6 @@ def main() -> None:
                         )
                     )
 
-            for attachment in attachments:
-                attachment_entries.append(
-                    (
-                        attachment,
-                        f"Container attachment copy ({attachment.name})",
-                        _guess_mime_type(attachment),
-                    )
-                )
-
             if metadata_sidecar is not None:
                 if metadata_sidecar.exists():
                     attachment_entries.append(
@@ -3604,13 +3600,44 @@ def main() -> None:
                     )
                 finally_cleanup_files.append(str(metadata_sidecar))
 
+            creation_date_to_apply = original_creation_date
+            if not creation_date_to_apply:
+                for key_name in ("creation_time", "com.apple.quicktime.creationdate"):
+                    raw_value = container_tags.get(key_name)
+                    if isinstance(raw_value, str):
+                        parsed = _parse_creation_date(raw_value)
+                        if parsed:
+                            creation_date_to_apply = parsed
+                            break
+
+            metadata_args: List[str]
+            try:
+                metadata_args = _prepare_container_metadata_args(
+                    remux_output,
+                    creation_date_to_apply,
+                    container_tags,
+                    finally_cleanup_files,
+                )
+            except RuntimeError as exc:
+                logging.error(
+                    "failed to prepare container metadata for %s: %s",
+                    src,
+                    exc,
+                )
+                mark_pending("failed to prepare container metadata")
+                continue
+
+            attachment_args = _build_attachment_args(attachment_entries)
+
             mux_cmd = [
                 "mkvmerge",
                 "-o",
                 remux_output,
                 "--disable-track-statistics-tags",
-                str(selected_output_path),
             ]
+            mux_cmd += metadata_args
+            mux_cmd += attachment_args
+            mux_cmd.append(str(selected_output_path))
             _print_command(mux_cmd)
             mux_proc = subprocess.run(mux_cmd)
             if mux_proc.returncode != 0:
@@ -3624,37 +3651,25 @@ def main() -> None:
                 continue
 
             try:
+                mux_size = os.path.getsize(remux_output)
+            except OSError as exc:
+                logging.info(
+                    "mkv size after mkvmerge for %s: unavailable (%s)",
+                    src,
+                    exc,
+                )
+            else:
+                logging.info(
+                    "mkv size after mkvmerge for %s: %s",
+                    src,
+                    _format_size_for_log(mux_size),
+                )
+
+            try:
                 os.replace(remux_output, stage_part)
             except OSError as exc:
                 logging.error("failed to finalize remuxed output for %s: %s", src, exc)
                 mark_pending("failed to finalize remuxed output")
-                continue
-            creation_date_to_apply = original_creation_date
-            if not creation_date_to_apply:
-                for key_name in ("creation_time", "com.apple.quicktime.creationdate"):
-                    raw_value = container_tags.get(key_name)
-                    if isinstance(raw_value, str):
-                        parsed = _parse_creation_date(raw_value)
-                        if parsed:
-                            creation_date_to_apply = parsed
-                            break
-            try:
-                _apply_container_metadata(
-                    stage_part,
-                    creation_date_to_apply,
-                    container_tags,
-                    finally_cleanup_files,
-                )
-            except RuntimeError as exc:
-                logging.error("failed to apply container metadata for %s: %s", src, exc)
-                mark_pending("failed to apply container metadata")
-                continue
-
-            try:
-                _attach_sidecar_files(stage_part, attachment_entries)
-            except RuntimeError as exc:
-                logging.error("failed to attach auxiliary outputs for %s: %s", src, exc)
-                mark_pending("failed to attach auxiliary outputs")
                 continue
 
             try:

--- a/containers/vcrunch/spec.md
+++ b/containers/vcrunch/spec.md
@@ -13,6 +13,7 @@
 * And I pass --svt-lp "<lp>"
 * And I run vcrunch
 * And vcrunch remuxes the encoded video with mkvmerge
+* And mkvmerge reports version "95.0"
 * Then vcrunch creates an AV1 file in "<out>"
 * And the file name ends with "<suffix>.mkv"
 * And "<manifest>" records "<src>" as done

--- a/containers/vcrunch/tests/test_script.py
+++ b/containers/vcrunch/tests/test_script.py
@@ -1618,15 +1618,15 @@ def test_mkvmerge_sets_creation_date_and_attachments(monkeypatch, tmp_path):
     assert output_video.exists()
     assert captured_mux_cmds
     mkv_cmd = captured_mux_cmds[0]
-    assert mkv_cmd[1] == "--disable-track-statistics-tags"
-    assert "--disable-track-statistics-tags" in mkv_cmd
+    assert mkv_cmd[1] == "-o"
+    assert mkv_cmd[3] == "--disable-track-statistics-tags"
     assert "--timestamps" not in mkv_cmd
     assert not captured_edit_cmds
     assert "--date" in mkv_cmd
     date_index = mkv_cmd.index("--date")
     assert mkv_cmd[date_index + 1] == "2024-09-28T15:42:11Z"
     out_index = mkv_cmd.index("-o")
-    assert out_index > date_index
+    assert out_index < date_index
     assert "--title" in mkv_cmd
     title_index = mkv_cmd.index("--title")
     assert mkv_cmd[title_index + 1] == "Original Title"

--- a/containers/vcrunch/tests/test_script.py
+++ b/containers/vcrunch/tests/test_script.py
@@ -1232,7 +1232,8 @@ def test_constant_quality_groups_and_command(monkeypatch, tmp_path):
                     output_path.parent.mkdir(parents=True, exist_ok=True)
                     output_path.write_bytes(b"encoded")
         elif cmd[0] == "mkvmerge":
-            output_path = Path(cmd[2])
+            out_index = cmd.index("-o")
+            output_path = Path(cmd[out_index + 1])
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_bytes(b"remuxed")
 
@@ -1424,7 +1425,8 @@ def test_constant_quality_ignores_fit_short_circuit(monkeypatch, tmp_path):
                     output_path.parent.mkdir(parents=True, exist_ok=True)
                     output_path.write_bytes(b"encoded")
         elif cmd[0] == "mkvmerge":
-            Path(cmd[2]).write_bytes(b"remuxed")
+            out_index = cmd.index("-o")
+            Path(cmd[out_index + 1]).write_bytes(b"remuxed")
 
         return types.SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
 
@@ -1544,7 +1546,8 @@ def test_mkvmerge_sets_creation_date_and_attachments(monkeypatch, tmp_path):
             return types.SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
         if cmd[0] == "mkvmerge":
             captured_mux_cmds.append(cmd)
-            output_path = Path(cmd[2])
+            out_index = cmd.index("-o")
+            output_path = Path(cmd[out_index + 1])
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_bytes(b"remuxed")
             return types.SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
@@ -1618,9 +1621,9 @@ def test_mkvmerge_sets_creation_date_and_attachments(monkeypatch, tmp_path):
     assert "--disable-track-statistics-tags" in mkv_cmd
     assert "--timestamps" not in mkv_cmd
     assert not captured_edit_cmds
-    assert "--date" in mkv_cmd
-    date_index = mkv_cmd.index("--date")
-    assert mkv_cmd[date_index + 1] == "2024-09-28T15:42:11Z"
+    date_tokens = [token for token in mkv_cmd if token.startswith("--date=")]
+    assert date_tokens
+    assert date_tokens[0] == "--date=2024-09-28T15:42:11Z"
     assert "--title" in mkv_cmd
     title_index = mkv_cmd.index("--title")
     assert mkv_cmd[title_index + 1] == "Original Title"
@@ -1731,7 +1734,8 @@ def test_mov_with_data_stream_outputs_mkv(monkeypatch, tmp_path):
                     output_path.parent.mkdir(parents=True, exist_ok=True)
                     output_path.write_bytes(b"encoded")
         elif cmd[0] == "mkvmerge":
-            output_path = Path(cmd[2])
+            out_index = cmd.index("-o")
+            output_path = Path(cmd[out_index + 1])
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_bytes(b"remuxed")
 
@@ -1890,7 +1894,8 @@ def test_low_bitrate_audio_stream_copied(monkeypatch, tmp_path):
                     output_path.parent.mkdir(parents=True, exist_ok=True)
                     output_path.write_bytes(b"encoded")
         elif cmd[0] == "mkvmerge":
-            Path(cmd[2]).write_bytes(b"remuxed")
+            out_index = cmd.index("-o")
+            Path(cmd[out_index + 1]).write_bytes(b"remuxed")
         return types.SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
 
     monkeypatch.setattr(script.subprocess, "run", fake_run)
@@ -2022,7 +2027,8 @@ def test_low_bitrate_video_stream_copied(monkeypatch, tmp_path):
                     output_path.parent.mkdir(parents=True, exist_ok=True)
                     output_path.write_bytes(b"encoded")
         elif cmd[0] == "mkvmerge":
-            Path(cmd[2]).write_bytes(b"remuxed")
+            out_index = cmd.index("-o")
+            Path(cmd[out_index + 1]).write_bytes(b"remuxed")
         return types.SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
 
     monkeypatch.setattr(script.subprocess, "run", fake_run)
@@ -2163,7 +2169,8 @@ def test_sidecar_files_are_renamed(monkeypatch, tmp_path):
                     output_path.parent.mkdir(parents=True, exist_ok=True)
                     output_path.write_bytes(b"encoded")
         elif cmd[0] == "mkvmerge":
-            output_path = Path(cmd[2])
+            out_index = cmd.index("-o")
+            output_path = Path(cmd[out_index + 1])
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_bytes(b"remuxed")
 

--- a/containers/vcrunch/tests/test_script.py
+++ b/containers/vcrunch/tests/test_script.py
@@ -1618,12 +1618,13 @@ def test_mkvmerge_sets_creation_date_and_attachments(monkeypatch, tmp_path):
     assert output_video.exists()
     assert captured_mux_cmds
     mkv_cmd = captured_mux_cmds[0]
+    assert mkv_cmd[1] == "-o"
     assert "--disable-track-statistics-tags" in mkv_cmd
     assert "--timestamps" not in mkv_cmd
     assert not captured_edit_cmds
-    date_tokens = [token for token in mkv_cmd if token.startswith("--date=")]
-    assert date_tokens
-    assert date_tokens[0] == "--date=2024-09-28T15:42:11Z"
+    assert "--date" in mkv_cmd
+    date_index = mkv_cmd.index("--date")
+    assert mkv_cmd[date_index + 1] == "2024-09-28T15:42:11Z"
     assert "--title" in mkv_cmd
     title_index = mkv_cmd.index("--title")
     assert mkv_cmd[title_index + 1] == "Original Title"

--- a/containers/vcrunch/tests/test_script.py
+++ b/containers/vcrunch/tests/test_script.py
@@ -1618,13 +1618,15 @@ def test_mkvmerge_sets_creation_date_and_attachments(monkeypatch, tmp_path):
     assert output_video.exists()
     assert captured_mux_cmds
     mkv_cmd = captured_mux_cmds[0]
-    assert mkv_cmd[1] == "-o"
+    assert mkv_cmd[1] == "--disable-track-statistics-tags"
     assert "--disable-track-statistics-tags" in mkv_cmd
     assert "--timestamps" not in mkv_cmd
     assert not captured_edit_cmds
     assert "--date" in mkv_cmd
     date_index = mkv_cmd.index("--date")
     assert mkv_cmd[date_index + 1] == "2024-09-28T15:42:11Z"
+    out_index = mkv_cmd.index("-o")
+    assert out_index > date_index
     assert "--title" in mkv_cmd
     title_index = mkv_cmd.index("--title")
     assert mkv_cmd[title_index + 1] == "Original Title"


### PR DESCRIPTION
## Summary
- build mkvmerge attachment arguments for sidecar exports while logging their sizes
- generate mkvmerge metadata options from container tags and log the final muxed size
- update vcrunch integration tests to expect metadata and attachments to be handled by mkvmerge

## Testing
- pre-commit run --all-files
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69018977f34c832b9d595d33a15ff6fe